### PR TITLE
Fixed error caused by signed value

### DIFF
--- a/script_fex.c
+++ b/script_fex.c
@@ -326,7 +326,7 @@ int script_parse_fex(FILE *in, const char *filename, struct script *script)
 						perror("malloc");
 					}
 				}
-			} else if (isdigit(*p)) {
+			} else if (isdigit(*p) || (*p == '-' && isdigit(*(p+1)))) {
 				long long v = 0;
 				char *end;
 				v = strtoll(p, &end, 0);


### PR DESCRIPTION
Entering signed value in fex field, i.e (-1) caused invalid character error.
