### PR TITLE
Support build of fel.c on NetBSD

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -17,6 +17,7 @@
 
 /* Needs _BSD_SOURCE for htole and letoh  */
 #define _BSD_SOURCE
+#define _NETBSD_SOURCE
 
 #include <libusb.h>
 #include <stdint.h>


### PR DESCRIPTION
_BSD_SOURCE doesn't work on NetBSD, so explicitly request the full native namespace.
