### PR TITLE
received a warning about attempting to concatenate an int with a string

### DIFF
--- a/fexc.c
+++ b/fexc.c
@@ -247,7 +247,13 @@ int main(int argc, char *argv[])
 
 	int app_mode = app_choose_mode(argv[0]);
 
-	const char *opt_string = "I:O:vq?"+ ((app_mode == 0)? 0: 4);
+	char str1[10];
+	char str2[2];
+	strcpy(str1, "I:O:vq?");
+	sprintf(str2, "%i", ((app_mode == 0)? 0: 4) );
+	strcat(str1, str2);
+	const char *opt_string = str1;
+	
 	int opt, ret = 1;
 	int verbose = 0;
 


### PR DESCRIPTION
the warning received:

``` bash
make bin2fex
gcc -g -O0 -Wall -Wextra -std=c99 -D_POSIX_C_SOURCE=200112L -Iinclude/  -o fexc fexc.c script.c script_uboot.c script_bin.c script_fex.c 
fexc.c:250:36: warning: adding 'int' to a string does not append to the string
      [-Wstring-plus-int]
        const char *opt_string = "I:O:vq?"+ ((app_mode == 0)? 0: 4);
                                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
fexc.c:250:36: note: use array indexing to silence this warning
        const char *opt_string = "I:O:vq?"+ ((app_mode == 0)? 0: 4);
                                          ^
                                 &        [                        ]
1 warning generated.
ln -s fexc bin2fex
```

the fix done here was to make two string buffers and concatenate them together. since itoa() is not standard, but sprintf() is, i used sprintf() to convert from an int to string.
