### PR TITLE
Make use of FEL library to implement device enumeration and selection by SID

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -987,6 +987,24 @@ static void felusb_list_devices(void)
 	exit(devices > 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
+static void select_by_sid(const char *sid_arg, int *busnum, int *devnum)
+{
+	char sid[36];
+	feldev_list_entry *list, *entry;
+
+	list = list_fel_devices(NULL);
+	for (entry = list; entry->soc_version.soc_id; entry++) {
+		snprintf(sid, sizeof(sid), "%08x:%08x:%08x:%08x",
+			entry->SID[0], entry->SID[1], entry->SID[2], entry->SID[3]);
+		if (strcmp(sid, sid_arg) == 0) {
+			*busnum = entry->busnum;
+			*devnum = entry->devnum;
+			break;
+		}
+	}
+	free(list);
+}
+
 int main(int argc, char **argv)
 {
 	bool uboot_autostart = false; /* flag for "uboot" command = U-Boot autostart */
@@ -994,6 +1012,7 @@ int main(int argc, char **argv)
 	bool device_list = false; /* -l switch, prints device list and exits */
 	feldev_handle *handle;
 	int busnum = -1, devnum = -1;
+	char *sid_arg = NULL;
 
 	if (argc <= 1) {
 		puts("sunxi-fel " VERSION "\n");
@@ -1002,6 +1021,7 @@ int main(int argc, char **argv)
 			"	-p, --progress			\"write\" transfers show a progress bar\n"
 			"	-l, --list			Enumerate all (USB) FEL devices and exit\n"
 			"	-d, --dev bus:devnum		Use specific USB bus and device number\n"
+			"	    --sid SID			Select device by SID key (exact match)\n"
 			"\n"
 			"	spl file			Load and execute U-Boot SPL\n"
 			"		If file additionally contains a main U-Boot binary\n"
@@ -1062,6 +1082,11 @@ int main(int argc, char **argv)
 				exit(1);
 			}
 			pr_info("Selecting USB Bus %03d Device %03d\n", busnum, devnum);
+		}
+		else if (strcmp(argv[1], "--sid") == 0 && argc > 2) {
+			sid_arg = argv[2];
+			argc -= 1;
+			argv += 1;
 		} else
 			break; /* no valid (prefix) option detected, exit loop */
 		argc -= 1;
@@ -1070,6 +1095,16 @@ int main(int argc, char **argv)
 
 	if (device_list)
 		felusb_list_devices(); /* and exit program afterwards */
+	if (sid_arg) {
+		/* try to set busnum and devnum according to "--sid" option */
+		select_by_sid(sid_arg, &busnum, &devnum);
+		if (busnum <= 0 || devnum <= 0) {
+			fprintf(stderr, "No matching FEL device found for SID '%s'\n",
+				sid_arg);
+			exit(1);
+		}
+		pr_info("Selecting FEL device %03d:%03d by SID\n", busnum, devnum);
+	}
 
 	handle = feldev_open(busnum, devnum, AW_USB_VENDOR_ID, AW_USB_PRODUCT_ID);
 


### PR DESCRIPTION
This allows code to be possibly reused, and is keeping better focus on the actual FEL functionality in `fel.c`.

---

Changes in [v1](https://github.com/linux-sunxi/sunxi-tools/commits/959de2eddb1f20f5b6ab2cbdf9f087ef6a6ea183): Initial version

Changes in [v2](https://github.com/linux-sunxi/sunxi-tools/commits/02faa6669622b07ef23af514af2499fb0fac182f):
- rebased on current master (9febb55)
- picked up the suggestion to incorporate _soc_sram_info_ (and FEL version data) into the handle
