### PR TITLE
Fixed issue in progress=true in file_upload

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -1492,7 +1492,9 @@ static unsigned int file_upload(libusb_device_handle *handle, size_t count,
 		void *buf = load_file(argv[i * 2 + 1], &size);
 		if (size > 0) {
 			uint32_t offset = strtoul(argv[i * 2], NULL, 0);
-			aw_write_buffer(handle, buf, offset, size, true);
+
+			/* fixed a problem with progress being passed in as true to aw_write_buffer */
+			aw_write_buffer(handle, buf, offset, size, (progress != NULL));
 
 			/* If we transferred a script, try to inform U-Boot about its address. */
 			if (get_image_type(buf, size) == IH_TYPE_SCRIPT)


### PR DESCRIPTION
This fixes a problem introduced with the new progress functionality. progress was hard-coded as true in the call to aw_write_buffer() in the file_upload() function instead of paying attention to the progress callback passed in. 