### PR TITLE
Upload progress fix2

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -1492,10 +1492,7 @@ static unsigned int file_upload(libusb_device_handle *handle, size_t count,
 		void *buf = load_file(argv[i * 2 + 1], &size);
 		if (size > 0) {
 			uint32_t offset = strtoul(argv[i * 2], NULL, 0);
-
-			/* fixed a problem with progress being passed in as true to aw_write_buffer */
 			aw_write_buffer(handle, buf, offset, size, (progress != NULL));
-
 			/* If we transferred a script, try to inform U-Boot about its address. */
 			if (get_image_type(buf, size) == IH_TYPE_SCRIPT)
 				pass_fel_information(handle, offset, 0);

--- a/fel.c
+++ b/fel.c
@@ -1492,7 +1492,9 @@ static unsigned int file_upload(libusb_device_handle *handle, size_t count,
 		void *buf = load_file(argv[i * 2 + 1], &size);
 		if (size > 0) {
 			uint32_t offset = strtoul(argv[i * 2], NULL, 0);
-			aw_write_buffer(handle, buf, offset, size, true);
+
+			/* fixed a problem with progress being passed in as true to aw_write_buffer */
+			aw_write_buffer(handle, buf, offset, size, (progress != NULL));
 
 			/* If we transferred a script, try to inform U-Boot about its address. */
 			if (get_image_type(buf, size) == IH_TYPE_SCRIPT)


### PR DESCRIPTION
This pull request removes my improper "fixed issue" comment in the source and just contains the necessary fix itself.

The issue encountered was that by setting progress=true, when usb_bulk_send() is eventually called, progress==true has the side effect of setting the chunk size to 128K always:
Line 104:	size_t max_chunk = progress ? 128 * 1024 : AW_USB_MAX_BULK_SEND;

Regards,
Howie