### PR TITLE
Makefile: Revert sunxi-pio change from 209633a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,13 @@ endif
 DEFAULT_CFLAGS += -Iinclude/
 
 # Tools useful on host and target
-TOOLS = sunxi-fexc sunxi-bootinfo sunxi-fel sunxi-nand-part
+TOOLS = sunxi-fexc sunxi-bootinfo sunxi-fel sunxi-nand-part sunxi-pio
 
 # Symlinks to sunxi-fexc
 FEXC_LINKS = bin2fex fex2bin
 
 # Tools which are only useful on the target
-TARGET_TOOLS = sunxi-meminfo sunxi-pio
+TARGET_TOOLS = sunxi-meminfo
 
 # Misc tools (of more "exotic" nature) not part of our default build / install
 MISC_TOOLS = phoenix_info sunxi-nand-image-builder
@@ -173,8 +173,6 @@ sunxi-bootinfo: bootinfo.c
 
 # target tools
 TARGET_CFLAGS = $(DEFAULT_CFLAGS) -static $(CFLAGS)
-sunxi-pio: pio.c
-	$(CROSS_CC) $(TARGET_CFLAGS) -o $@ $<
 sunxi-meminfo: meminfo.c
 	$(CROSS_CC) $(TARGET_CFLAGS) -o $@ $<
 sunxi-script_extractor: script_extractor.c


### PR DESCRIPTION
The previous commit had introduced a new build rule that made
sunxi-pio always (cross-)compile as part of TARGET_TOOLS. This
originated from a misunderstanding, and is wrong - sunxi-pio
should be part of TOOLS instead.

sunxi-pio is a "dual mode" utility. When run natively on a sunxi
SoC, it can mmap() and manipulate the PIO registers directly. But
it also supports file-based operation, to be used in conjunction
with sunxi-fel (after uploading fel-pio.bin thunk code). This
should work over USB from non-sunxi hosts, and thus puts sunxi-pio
in the TOOLS category. See the fel-gpio shell script for details.

Signed-off-by: Bernhard Nortmann <bernhard.nortmann@web.de>