### PR TITLE
fel: Add SID register address for A80

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -146,6 +146,7 @@ soc_info_t soc_info_table[] = {
 		.scratch_addr = 0x11000,
 		.thunk_addr   = 0x23400, .thunk_size = 0x200,
 		.swap_buffers = a80_sram_swap_buffers,
+		.sid_addr     = 0x01c0e200,
 	},{
 		.soc_id       = 0x1673, /* Allwinner A83T */
 		.scratch_addr = 0x1000,


### PR DESCRIPTION
The SID block in the A80 is at 0x01c0e000, with the e-fuses we care
about at offset 0x200 within the block.

Signed-off-by: Chen-Yu Tsai <wens@csie.org>