### PR TITLE
fel: workaround H3 SID issue

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -276,11 +276,49 @@ void fel_writel(feldev_handle *dev, uint32_t addr, uint32_t val)
 	fel_writel_n(dev, addr, &val, 1);
 }
 
+#define EFUSE_PRCTL 0x40
+#define EFUSE_RDKEY 0x60
+
+#define EFUSE_OP_LOCK 0xAC
+
+#define EFUSE_SRAM_BASE 0x200
+
+uint32_t aw_fel_efuse_read(feldev_handle *dev, uint32_t offset)
+{
+	soc_info_t *soc_info = dev->soc_info;
+	uint32_t reg_val;
+
+	uint32_t efuse_base = soc_info->sid_addr - EFUSE_SRAM_BASE;
+
+	reg_val = fel_readl(dev, efuse_base + EFUSE_PRCTL);
+	reg_val &= ~(((0x1ff) << 16) | 0x3);
+	reg_val |= (offset << 16);
+	fel_writel(dev, efuse_base + EFUSE_PRCTL, reg_val);
+
+	reg_val &= ~(((0xff) << 8) | 0x3);
+	reg_val |= (EFUSE_OP_LOCK << 8) | 0x2;
+	fel_writel(dev, efuse_base + EFUSE_PRCTL, reg_val);
+
+	while (fel_readl(dev, efuse_base + EFUSE_PRCTL) & 0x2);
+
+	reg_val &= ~(((0x1ff) << 16) | ((0xff) << 8) | 0x3);
+	fel_writel(dev, efuse_base + EFUSE_PRCTL, reg_val);
+
+	return fel_readl(dev, efuse_base + EFUSE_RDKEY);
+}
+
 void aw_fel_print_sid(feldev_handle *dev)
 {
 	soc_info_t *soc_info = dev->soc_info;
 	if (soc_info->sid_addr) {
 		pr_info("SID key (e-fuses) at 0x%08X\n", soc_info->sid_addr);
+
+		if(soc_info->sid_fix) {
+			pr_info("SID key needs fix due to silicon bug.\n");
+			for (uint32_t i = 0; i < 0x10; i+=4) {
+				aw_fel_efuse_read(dev, i);
+			}
+		}
 
 		uint32_t key[4];
 		fel_readl_n(dev, soc_info->sid_addr, key, 4);

--- a/soc_info.c
+++ b/soc_info.c
@@ -170,6 +170,7 @@ soc_info_t soc_info_table[] = {
 		.thunk_addr   = 0xA200, .thunk_size = 0x200,
 		.swap_buffers = a10_a13_a20_sram_swap_buffers,
 		.sid_addr     = 0x01C14200,
+		.sid_fix      = true,
 	},{
 		.soc_id       = 0x1718, /* Allwinner H5 */
 		.name         = "H5",

--- a/soc_info.h
+++ b/soc_info.h
@@ -84,6 +84,7 @@ typedef struct {
 	uint32_t           mmu_tt_addr;  /* MMU translation table address */
 	uint32_t           sid_addr;     /* base address for SID_KEY[0-3] registers */
 	uint32_t           rvbar_reg;    /* MMIO address of RVBARADDR0_L register */
+	bool               sid_fix;      /* Workaround H3 SID problem */
 	sram_swap_buffers *swap_buffers;
 } soc_info_t;
 


### PR DESCRIPTION
H3 SID controller has some bug, that makes the initial value at
0x01c14200 wrong.

This commit workarounds this bug by reading them with register access
first.

Signed-off-by: Icenowy Zheng <icenowy@aosc.xyz>