### PR TITLE
fel: SMC workaround for the Allwinner SoCs with the secure bit set in eFUSE

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -148,6 +148,8 @@ soc_info_t soc_info_table[] = {
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
 		.rvbar_reg    = 0x017000A0,
+		/* Check L.NOP in the OpenRISC reset vector */
+		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
 	},{
 		.soc_id       = 0x1639, /* Allwinner A80 */
 		.name         = "A80",
@@ -175,6 +177,8 @@ soc_info_t soc_info_table[] = {
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
 		.sid_fix      = true,
+		/* Check L.NOP in the OpenRISC reset vector */
+		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
 	},{
 		.soc_id       = 0x1681, /* Allwinner V3s */
 		.name         = "V3s",
@@ -193,6 +197,8 @@ soc_info_t soc_info_table[] = {
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
 		.rvbar_reg    = 0x017000A0,
+		/* Check L.NOP in the OpenRISC reset vector */
+		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
 	},{
 		.soc_id       = 0x1701, /* Allwinner R40 */
 		.name         = "R40",


### PR DESCRIPTION
A one time programmable secure bit in the eFUSE radically changes the boot behaviour on some SoCs (H3/A64/H64). A new bootloader header format https://linux-sunxi.org/TOC0 replaces the old eGON.BT0. Also the FEL handler starts as non-secure and has no access to a lot of resources (SID, SRAM A2, etc.). Fortunately a workaround to switch FEL into the secure mode exists and these patches implement it.