### PR TITLE
Added support for '-' and '/' characters.

### DIFF
--- a/script_bin.c
+++ b/script_bin.c
@@ -242,7 +242,7 @@ static int decompile_section(void *bin, size_t bin_size,
 		words	= (entry->pattern >>  0) & 0xffff;
 
 		for (char *p = entry->name; *p; p++)
-			if (!(isalnum(*p) || *p == '_')) {
+			if (!(isalnum(*p) || *p == '_' || *p == '-' || *p == '/')) {
 				pr_info("Warning: Malformed entry key \"%s\"\n",
 					entry->name);
 				break;

--- a/script_fex.c
+++ b/script_fex.c
@@ -211,7 +211,7 @@ int script_parse_fex(FILE *in, const char *filename, struct script *script)
 		if (*s == '[') {
 			/* section */
 			char *p = ++s;
-			while (isalnum(*p) || *p == '_')
+			while (isalnum(*p) || *p == '_' || *p == '-' || *p == '/')
 				p++;
 
 			if (*p == ']' && *(p+1) == '\0') {
@@ -239,7 +239,7 @@ int script_parse_fex(FILE *in, const char *filename, struct script *script)
 				goto parse_error;
 			};
 
-			while (isalnum(*p) || *p == '_')
+			while (isalnum(*p) || *p == '_' || *p == '-' || *p == '/')
 				p++;
 			mark = p;
 			p = skip_blank(p);


### PR DESCRIPTION
Newer fex files like the one [here](https://github.com/OrangePiLibra/OrangePiH5_external/blob/master/sys_config/OrangePiH5_PC2_sys_config.fex) cannot be converted to bin.

> invalid character at 4.
There are fex files with "-" and "/" characters in their section header or key. These characters aren't supported with fex2bin.