### PR TITLE
fel: enable A83T MMU

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -163,6 +163,7 @@ soc_info_t soc_info_table[] = {
 		.soc_id       = 0x1673, /* Allwinner A83T */
 		.name         = "A83T",
 		.scratch_addr = 0x1000,
+		.mmu_tt_addr  = 0x44000,
 		.thunk_addr   = 0x46E00, .thunk_size = 0x200,
 		.swap_buffers = ar100_abusing_sram_swap_buffers,
 		.sid_base     = 0x01C14000,


### PR DESCRIPTION
As per the wiki[1] set ttbr0 to 0x44000 to enable the MMU. Transfer
speed is increased from 191KB/s to ~800KB/s which is handy when
transferring larger kernels and root filesystems.

Tested on a custom H8/A83T board.

[1] https://linux-sunxi.org/FEL/USBBoot