### PR TITLE
Fix two warnings about implicit fallthrough.

### DIFF
--- a/fexc.c
+++ b/fexc.c
@@ -310,6 +310,7 @@ show_usage:
 	switch (argc - optind) {
 	case 2:
 		filename[1] = argv[optind+1]; /* out */
+		/* fall-through */
 	case 1:
 		if (strcmp(argv[optind], "-") != 0)
 			filename[0] = argv[optind]; /* in */

--- a/pio.c
+++ b/pio.c
@@ -165,7 +165,7 @@ static void print(const char *buf)
 
 static const char *argv0;
 
-static void usage(int rc )
+static __attribute__((noreturn)) void usage(int rc )
 {
 	fputs("sunxi-pio " VERSION "\n\n", stderr);
 	fprintf(stderr, "usage: %s -m|-i input [-o output] pin..\n", argv0);


### PR DESCRIPTION
In the first case:

    pio.c: In function ‘main’:
    pio.c:355:4: warning: this statement may fall through [-Wimplicit-fallthrough=]
        usage(0);
        ^~~~~~~~
    pio.c:356:3: note: here
       case 'm':
       ^~~~

The fallthrough is not intended because `usage()` never returns (it calls
`exit` unconditionally). Annotate as `noreturn` so the compiler realises this.

In the second case:

    fexc.c: In function ‘main’:
    fexc.c:312:15: warning: this statement may fall through [-Wimplicit-fallthrough=]
       filename[1] = argv[optind+1]; /* out */
       ~~~~~~~~~~~~^~~~~~~~~~~~~~~~
    fexc.c:313:2: note: here
      case 1:
      ^~~~

The fallthrough appears to be intended (the two argument case is a superset of
the one argument case). Annotate with a comment which tells the compiler this
is intended.

Signed-off-by: Ian Campbell <ijc@hellion.org.uk>