### PR TITLE
FEL: introduce semantic versioning for SPL header

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -947,8 +947,13 @@ void aw_fel_process_spl_and_uboot(feldev_handle *dev, const char *filename)
  * the result is "true".
  */
 #define SPL_SIGNATURE			"SPL" /* marks "sunxi" header */
-#define SPL_MIN_VERSION			1 /* minimum required version */
-#define SPL_MAX_VERSION			2 /* maximum supported version */
+#define SPL_MAJOR_BITS			3
+#define SPL_MINOR_BITS			5
+#define SPL_VERSION(maj, min)		\
+	((((maj) & ((1U << SPL_MAJOR_BITS) - 1)) << SPL_MINOR_BITS) | \
+	((min) & ((1U << SPL_MINOR_BITS) - 1)))
+#define SPL_MIN_VERSION			SPL_VERSION(0, 1)
+#define SPL_MAX_VERSION			SPL_VERSION(0, 31)
 bool have_sunxi_spl(feldev_handle *dev, uint32_t spl_addr)
 {
 	uint8_t spl_signature[4];


### PR DESCRIPTION
Every addition of a new feature to the SPL header currently requires us
to update the FEL tool, to teach it about the new supported maximum
value. Many times the FEL tool doesn't really care, but complains
anyway - and refuses to load.
Let's introduce semantic versioning [1] for this field, where backwards
compatible additions just increase a minor number, but incompatible
changes require bumping the major version.
We have 8 bits for the SPL header version, let's split this to have 3 bits
for the major and 5 bit for the minor version number.

[1] https://semver.org

Signed-off-by: Andre Przywara <osp@andrep.de>
Signed-off-by: Icenowy Zheng <icenowy@aosc.io>

=========================

As the semantic versioning of SPL header is already accepted by
mainline U-Boot 2018.11, and the header version is raised to v0.3,
it's now needed to merge this patch into sunxi-tools, otherwise
sunxi-tools will fail to FEL boot U-Boot 2018.11.

Thanks
Icenowy