### PR TITLE
H6 and R40 support for SPI flash access

### DIFF
--- a/fel-spiflash.c
+++ b/fel-spiflash.c
@@ -173,6 +173,7 @@ static bool spi0_init(feldev_handle *dev)
 		gpio_set_cfgpin(dev, PC, 3, SUNXI_GPC_SPI0);
 		break;
 	case 0x1651: /* Allwinner A20 */
+	case 0x1701: /* Allwinner R40 */
 		gpio_set_cfgpin(dev, PC, 0, SUNXI_GPC_SPI0);
 		gpio_set_cfgpin(dev, PC, 1, SUNXI_GPC_SPI0);
 		gpio_set_cfgpin(dev, PC, 2, SUNXI_GPC_SPI0);

--- a/fel-spiflash.c
+++ b/fel-spiflash.c
@@ -85,7 +85,7 @@ void fel_writel(feldev_handle *dev, uint32_t addr, uint32_t val);
 #define SUN4I_CTL_RF_RST            (1 << 9)
 #define SUN4I_CTL_XCH               (1 << 10)
 
-#define SUN6I_TCR_XCH               (1 << 31)
+#define SUN6I_TCR_XCH               (1U << 31)
 
 #define SUN4I_SPI0_CCTL             (0x01C05000 + 0x1C)
 #define SUN4I_SPI0_CTL              (0x01C05000 + 0x08)
@@ -208,10 +208,10 @@ static bool spi0_init(feldev_handle *dev)
 	if (spi_is_sun6i(dev)) {
 		/* Enable SPI in the master mode and do a soft reset */
 		reg_val = readl(SUN6I_SPI0_GCR);
-		reg_val |= (1 << 31) | 3;
+		reg_val |= (1U << 31) | 3;
 		writel(reg_val, SUN6I_SPI0_GCR);
 		/* Wait for completion */
-		while (readl(SUN6I_SPI0_GCR) & (1 << 31)) {}
+		while (readl(SUN6I_SPI0_GCR) & (1U << 31)) {}
 	} else {
 		reg_val = readl(SUN4I_SPI0_CTL);
 		reg_val |= SUN4I_CTL_MASTER;
@@ -489,7 +489,7 @@ void aw_fel_spiflash_info(feldev_handle *dev)
 	}
 
 	printf("Manufacturer: %s (%02Xh), model: %02Xh, size: %d bytes.\n",
-	       manufacturer, buf[3], buf[4], (1 << buf[5]));
+	       manufacturer, buf[3], buf[4], (1U << buf[5]));
 }
 
 /*

--- a/fel-spiflash.c
+++ b/fel-spiflash.c
@@ -188,21 +188,24 @@ static bool spi0_init(feldev_handle *dev)
 		return false;
 	}
 
-	reg_val = readl(CCM_AHB_GATING0);
-	reg_val |= CCM_AHB_GATE_SPI0;
-	writel(reg_val, CCM_AHB_GATING0);
-
-	/* 24MHz from OSC24M */
-	writel((1 << 31), CCM_SPI0_CLK);
-	/* divide by 4 */
-	writel(CCM_SPI0_CLK_DIV_BY_4, spi_is_sun6i(dev) ? SUN6I_SPI0_CCTL :
-							  SUN4I_SPI0_CCTL);
-
 	if (spi_is_sun6i(dev)) {
 		/* Deassert SPI0 reset */
 		reg_val = readl(SUN6I_BUS_SOFT_RST_REG0);
 		reg_val |= SUN6I_SPI0_RST;
 		writel(reg_val, SUN6I_BUS_SOFT_RST_REG0);
+	}
+
+	reg_val = readl(CCM_AHB_GATING0);
+	reg_val |= CCM_AHB_GATE_SPI0;
+	writel(reg_val, CCM_AHB_GATING0);
+
+	/* divide by 4 */
+	writel(CCM_SPI0_CLK_DIV_BY_4, spi_is_sun6i(dev) ? SUN6I_SPI0_CCTL :
+							  SUN4I_SPI0_CCTL);
+	/* Choose 24MHz from OSC24M and enable clock */
+	writel((1U << 31), CCM_SPI0_CLK);
+
+	if (spi_is_sun6i(dev)) {
 		/* Enable SPI in the master mode and do a soft reset */
 		reg_val = readl(SUN6I_SPI0_GCR);
 		reg_val |= (1 << 31) | 3;

--- a/fel-spiflash.c
+++ b/fel-spiflash.c
@@ -109,17 +109,27 @@ void fel_writel(feldev_handle *dev, uint32_t addr, uint32_t val);
 #define CCM_SPI0_CLK_DIV_BY_4       (0x1001)
 #define CCM_SPI0_CLK_DIV_BY_6       (0x1002)
 
+static bool is_h6(feldev_handle *dev)
+{
+	soc_info_t *soc_info = dev->soc_info;
+
+	return soc_info->soc_id == 0x1728;
+}
+
 /*
  * Configure pin function on a GPIO port
  */
 static void gpio_set_cfgpin(feldev_handle *dev, int port_num, int pin_num,
 			    int val)
 {
-	uint32_t port_base = 0x01C20800 + port_num * 0x24;
-	uint32_t cfg_reg   = port_base + 4 * (pin_num / 8);
+	uint32_t port_base = port_num * 0x24;
+	uint32_t cfg_reg   = 4 * (pin_num / 8);
 	uint32_t pin_idx   = pin_num % 8;
-	uint32_t x = readl(cfg_reg);
-	x &= ~(0x7 << (pin_idx * 4));
+	uint32_t x;
+
+	cfg_reg += port_base + (is_h6(dev) ? 0x0300B000 : 0x01C20800);
+
+	x = readl(cfg_reg) & ~(0x7 << (pin_idx * 4));
 	x |= val << (pin_idx * 4);
 	writel(x, cfg_reg);
 }

--- a/soc_info.c
+++ b/soc_info.c
@@ -127,6 +127,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = a10_a13_a20_sram_swap_buffers,
 		.needs_l2en   = true,
 		.sid_base     = 0x01C23800,
+		.spi0_base    = 0x01C68000,
 	},{
 		.soc_id       = 0x1651, /* Allwinner A20 */
 		.name         = "A20",
@@ -134,6 +135,7 @@ soc_info_t soc_info_table[] = {
 		.thunk_addr   = 0xA200, .thunk_size = 0x200,
 		.swap_buffers = a10_a13_a20_sram_swap_buffers,
 		.sid_base     = 0x01C23800,
+		.spi0_base    = 0x01C05000,
 	},{
 		.soc_id       = 0x1650, /* Allwinner A23 */
 		.name         = "A23",
@@ -163,6 +165,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = a64_sram_swap_buffers,
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
+		.spi0_base    = 0x01C68000,
 		.rvbar_reg    = 0x017000A0,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
@@ -192,6 +195,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = a10_a13_a20_sram_swap_buffers,
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
+		.spi0_base    = 0x01C68000,
 		.sid_fix      = true,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
@@ -212,6 +216,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = a64_sram_swap_buffers,
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
+		.spi0_base    = 0x01C68000,
 		.rvbar_reg    = 0x017000A0,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,

--- a/soc_info.c
+++ b/soc_info.c
@@ -228,6 +228,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = a10_a13_a20_sram_swap_buffers,
 		.sid_base     = 0x01C1B000,
 		.sid_offset   = 0x200,
+		.spi0_base    = 0x01C05000,
 	},{
 		.soc_id       = 0x1728, /* Allwinner H6 */
 		.name         = "H6",

--- a/soc_info.c
+++ b/soc_info.c
@@ -238,6 +238,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = h6_sram_swap_buffers,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.spi0_base    = 0x05010000,
 		.rvbar_reg    = 0x09010040,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x100004,

--- a/soc_info.h
+++ b/soc_info.h
@@ -100,6 +100,7 @@ typedef struct {
 	uint32_t           mmu_tt_addr;  /* MMU translation table address */
 	uint32_t           sid_base;     /* base address for SID registers */
 	uint32_t           sid_offset;   /* offset for SID_KEY[0-3], "root key" */
+	uint32_t           spi0_base;    /* base address for SPI0 block */
 	uint32_t           rvbar_reg;    /* MMIO address of RVBARADDR0_L register */
 	bool               sid_fix;      /* Use SID workaround (read via register) */
 	/* Use SMC workaround (enter secure mode) if can't read from this address */


### PR DESCRIPTION
The spiflash commands in sunxi-tools were not supporting the Allwinner H6 SoC so far, this series fixes this. While at it, add support for the R40 as well, since I have a board lying around here.
Tested on Pine H64 and Bananapi M2 Berry, regression tested on Pine64-LTS, OrangePi PC2 and OrangePi Zero.

Please review and test!

