### PR TITLE
Provide a wrapper for reset via watchdog

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -110,6 +110,16 @@ sram_swap_buffers h6_sram_swap_buffers[] = {
 	{ .size = 0 }  /* End of the table */
 };
 
+const watchdog_info wd_a10_compat = {
+	.reg_mode = 0x01C20C94,
+	.reg_mode_value = 3,
+};
+
+const watchdog_info wd_h3_compat = {
+	.reg_mode = 0x01C20Cb8,
+	.reg_mode_value = 1,
+};
+
 soc_info_t soc_info_table[] = {
 	{
 		.soc_id       = 0x1623, /* Allwinner A10 */
@@ -119,6 +129,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = a10_a13_a20_sram_swap_buffers,
 		.needs_l2en   = true,
 		.sid_base     = 0x01C23800,
+		.watchdog     = &wd_a10_compat,
 	},{
 		.soc_id       = 0x1625, /* Allwinner A10s, A13, R8 */
 		.name         = "A13",
@@ -195,6 +206,7 @@ soc_info_t soc_info_table[] = {
 		.sid_fix      = true,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
+		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1681, /* Allwinner V3s */
 		.name         = "V3s",
@@ -215,6 +227,7 @@ soc_info_t soc_info_table[] = {
 		.rvbar_reg    = 0x017000A0,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
+		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1701, /* Allwinner R40 */
 		.name         = "R40",

--- a/soc_info.h
+++ b/soc_info.h
@@ -52,6 +52,16 @@ typedef struct {
 } sram_swap_buffers;
 
 /*
+ * Contains information on the watchdog peripheral, to enable reset
+ */
+typedef struct {
+	/* Register that needs to be written to */
+	uint32_t reg_mode;
+	/* Value to write to trigger a reset */
+	uint32_t reg_mode_value;
+} watchdog_info;
+
+/*
  * Each SoC variant may have its own list of memory buffers to be exchanged
  * and the information about the placement of the thunk code, which handles
  * the transition of execution from the BROM FEL code to the U-Boot SPL and
@@ -101,6 +111,7 @@ typedef struct {
 	uint32_t           sid_base;     /* base address for SID registers */
 	uint32_t           sid_offset;   /* offset for SID_KEY[0-3], "root key" */
 	uint32_t           rvbar_reg;    /* MMIO address of RVBARADDR0_L register */
+	const watchdog_info *watchdog;   /* Used for reset */
 	bool               sid_fix;      /* Use SID workaround (read via register) */
 	/* Use SMC workaround (enter secure mode) if can't read from this address */
 	uint32_t           needs_smc_workaround_if_zero_word_at_addr;


### PR DESCRIPTION
The watchdog register isn't in the same place, nor uses the same values
to trigger a reset.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

Incomplete as far as filling in the structure for all the socs, if there's support for this, I can go and check more datasheets, but I didn't want to go and do all that datasheet trawling up front.  I only have a h3 board locally to test with unfortunately.  Inspiration from https://linux-sunxi.org/FEL#Tips_and_tricks