### PR TITLE
Add support for reading A10 SPI flash

### DIFF
--- a/fel-spiflash.c
+++ b/fel-spiflash.c
@@ -160,6 +160,7 @@ static bool spi0_init(feldev_handle *dev)
 		gpio_set_cfgpin(dev, PC, 2, SUNXI_GPC_SPI0);
 		gpio_set_cfgpin(dev, PC, 3, SUNXI_GPC_SPI0);
 		break;
+	case 0x1623: /* Allwinner A10 */
 	case 0x1651: /* Allwinner A20 */
 		gpio_set_cfgpin(dev, PC, 0, SUNXI_GPC_SPI0);
 		gpio_set_cfgpin(dev, PC, 1, SUNXI_GPC_SPI0);


### PR DESCRIPTION
This is a trivial fix, it just adds the A10 to the supported list. I've tested it and was able to successfully read the entire SPI flash of the device, but did not try writing yet.