### PR TITLE
spi: fix GPIO base address

### DIFF
--- a/fel-spiflash.c
+++ b/fel-spiflash.c
@@ -125,7 +125,7 @@ static uint32_t gpio_base(feldev_handle *dev)
 	case 0x1817: /* V831 */
 		return 0x0300B000;
 	default:
-		return 0x01C28000;
+		return 0x01C20800;
 	}
 }
 


### PR DESCRIPTION
This PR fixes a typo which renders SPI flash functions unable to use for most devices.

Fixes #143.

Signed-off-by: Nazım Gediz Aydındoğmuş <gedizaydindogmus@gmail.com>