### PR TITLE
Fix missing include for `be32toh`

### DIFF
--- a/fit_image.c
+++ b/fit_image.c
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <endian.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <libfdt.h>


### PR DESCRIPTION
This fails on some hosts with:

```

fit_image.c: In function ‘fdt_getprop_u32’:
fit_image.c:86:9: warning: implicit declaration of function ‘be32toh’ [-Wimplicit-function-declaration]
  return be32toh(*(uint32_t *)prop->data);
         ^~~~~~~
/tmp/cc9RgHcG.o: In function `fdt_getprop_u32':
fit_image.c:(.text+0x1a9): undefined reference to `be32toh'
```
