### PR TITLE
README: Add more information about other requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ To build this, get a toolchain and run:
 Compilation requires the development version of *libusb-1.0* (include header
 and library) to be installed for `sunxi-fel`. Unless you explicitly pass
 *LIBUSB_CFLAGS* and *LIBUSB_LIBS* to the make utility, `pkg-config` is also
-needed.
+needed. Development versions of zlib and libfdt are also required.
+
+To install the dependencies on Ubuntu 20.04 using package manager:
+
+```bash
+sudo apt install libusb-1.0-0-dev libz-dev libfdt-dev
+```
 
 Available build targets:
 


### PR DESCRIPTION
There are two more dependencies in addition to libusb and pkgconfig, which

are libz and libfdt. Tell about them and give an example command to install

the packages through apt.

Signed-off-by: Nazım Gediz Aydındoğmuş <gedizaydindogmus@gmail.com>