### PR TITLE
nandpart and fit-image build fixes

### DIFF
--- a/fit_image.c
+++ b/fit_image.c
@@ -77,13 +77,13 @@ static int fit_parse_arch(const char *value)
 
 static uint32_t fdt_getprop_u32(const void *fdt, int node, const char *name)
 {
-	const struct fdt_property *prop;
+	const fdt32_t *val;
 
-	prop = fdt_get_property(fdt, node, name, NULL);
-	if (!prop)
+	val = fdt_getprop(fdt, node, name, NULL);
+	if (!val)
 		return ~0U;
 
-	return be32toh(*(uint32_t *)prop->data);
+	return fdt32_to_cpu(*val);
 }
 
 static const char *fdt_getprop_str(const void *fdt, int node, const char *name)

--- a/nand-part.c
+++ b/nand-part.c
@@ -90,7 +90,7 @@ static MBR *_get_mbr(int fd, int mbr_num, int force)
 		printf("check partition table copy %d: ", mbr_num);
 		printmbrheader(mbr);
 		if (force) {
-			strncpy((char *)mbr->magic, MBR_MAGIC, 8);
+			memcpy(mbr->magic, MBR_MAGIC, 8);
 			mbr->version = MBR_VERSION;
 			return mbr;
 		}


### PR DESCRIPTION
Two build fixes, one for newer GCCs (resolves #161), and one for some non-standard setup (couldn't reproduce, but see the problem), resolves #158.