### PR TITLE
Add license header to tests/*

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,20 @@
 #
 # tests/Makefile
 #
+# Copyright (C) 2016  Bernhard Nortmann <bernhard.nortmann@web.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 BOARDS_URL := https://github.com/linux-sunxi/sunxi-boards/archive/master.zip
 BOARDS_DIR := sunxi-boards

--- a/tests/fextest.sh
+++ b/tests/fextest.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+#
+# Copyright (C) 2016  Bernhard Nortmann <bernhard.nortmann@web.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 echo $0 $*
 FEX2BIN=../fex2bin
 BIN2FEX=../bin2fex

--- a/tests/test_all_fex.sh
+++ b/tests/test_all_fex.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
+#
+# Copyright (C) 2016  Bernhard Nortmann <bernhard.nortmann@web.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 FEXFILES=fexfiles.lst
 find $1 -name '*.fex' > ${FEXFILES}
 while read fex; do

--- a/tests/test_bin2fex_corner_cases.sh
+++ b/tests/test_bin2fex_corner_cases.sh
@@ -2,6 +2,21 @@
 #
 # === Test errors / corner cases of "bin2fex", improving on code coverage ===
 #
+# Copyright (C) 2016  Bernhard Nortmann <bernhard.nortmann@web.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 BIN2FEX=../bin2fex
 TESTFILE=sunxi-boards/sys_config/a10/a10-olinuxino-lime
 # use sunxi-fexc in "fex2bin" mode, testing explicit parameters at the same time

--- a/tests/test_fex2bin_corner_cases.sh
+++ b/tests/test_fex2bin_corner_cases.sh
@@ -2,6 +2,21 @@
 #
 # === Test errors / corner cases of "fex2bin", improving on code coverage ===
 #
+# Copyright (C) 2016  Bernhard Nortmann <bernhard.nortmann@web.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 FEX2BIN=../fex2bin
 
 function expect () {


### PR DESCRIPTION
These files were all originally by Bernhard in 2016 via these commits:

8445d71 unify-fex: Use int64_t and portable format specifiers for its output
f957f89 fextest: Add a dedicated rule for (CI-)testing sunxi-boards
6ec3876 tests: Improve code coverage by testing corner cases
cd5a0a3 tests: Improve on testing fexc
5cbb0c9 tests: Introduce a basic testing framework

and have not otherwise been touched. The header was added to unify-fex.c when
it was added in cd5a0a3303cb ("tests: Improve on testing fexc") but not to the
other files.

The license in unify-fex.c is the GPLv2+ which corresponds to the content of
LICENSE.md both at the time and now. I think therefore that it is appropriate
to duplicate the header into the other files (changing only the character used
for comments to suit)

--- 

I think it's pretty clear with/without the explicit header what the intended is, but Debian likes me (as package maintainer) to be a bit pedantic about this sort of thing (see also: 227c7e031f24ee829d1eb81749ea3d75b35bb72f). 

/cc @n1tehawk