### PR TITLE
V853 support

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -182,6 +182,11 @@ const watchdog_info wd_h6_compat = {
 	.reg_mode_value = 1,
 };
 
+const watchdog_info wd_v853_compat = {
+	.reg_mode = 0x020500b8,
+	.reg_mode_value = 0x16aa0001,
+};
+
 soc_info_t soc_info_table[] = {
 	{
 		.soc_id       = 0x1623, /* Allwinner A10 */
@@ -392,6 +397,18 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.rvbar_reg    = 0x08100040,
 		.watchdog     = &wd_h6_compat,
+	},{
+		.soc_id       = 0x1886, /* Allwinner V853 */
+		.name         = "V853",
+		.spl_addr     = 0x20000,
+		.scratch_addr = 0x21000,
+		.thunk_addr   = 0x3A200, .thunk_size = 0x200,
+		.swap_buffers = v831_sram_swap_buffers,
+		.sram_size    = 132 * 1024,
+		.sid_base     = 0x03006000,
+		.sid_offset   = 0x200,
+		.icache_fix   = true,
+		.watchdog     = &wd_v853_compat,
 	},{
 		.swap_buffers = NULL /* End of the table */
 	}

--- a/soc_info.h
+++ b/soc_info.h
@@ -113,6 +113,8 @@ typedef struct {
 	uint32_t           rvbar_reg;    /* MMIO address of RVBARADDR0_L register */
 	const watchdog_info *watchdog;   /* Used for reset */
 	bool               sid_fix;      /* Use SID workaround (read via register) */
+	/* Use I$ workaround (disable I$ before first write to prevent stale thunk */
+	bool               icache_fix;
 	/* Use SMC workaround (enter secure mode) if can't read from this address */
 	uint32_t           needs_smc_workaround_if_zero_word_at_addr;
 	uint32_t           sram_size;	/* Usable contiguous SRAM at spl_addr */


### PR DESCRIPTION
This PR contains V853 support. (It comes even before V853 document release...)

V853 BROM enables I-Cache, but without FEL write command invalidating it, which makes uploading different thunks to the same address not working. It's currently worked around by disabling I-Cache.

In addition, V853 has a GPIO controller with a new register map (the same with D1), support for this GPIO controller is also added to uart0-helloworld-sdboot.