### PR TITLE
Allwinner V5 and R528/T113 support

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -422,6 +422,17 @@ soc_info_t soc_info_table[] = {
 		.icache_fix   = true,
 		.watchdog     = &wd_v853_compat,
 	},{
+		.soc_id       = 0x1721, /* Allwinner V5 */
+		.name         = "V5",
+		.spl_addr     = 0x20000,
+		.scratch_addr = 0x21000,
+		.thunk_addr   = 0x42200, .thunk_size = 0x200,
+		.swap_buffers = h6_sram_swap_buffers,
+		.sram_size    = 136 * 1024,
+		.sid_base     = 0x03006000,
+		.sid_offset   = 0x200,
+		.watchdog     = &wd_h6_compat,
+	},{
 		.swap_buffers = NULL /* End of the table */
 	}
 };

--- a/soc_info.c
+++ b/soc_info.c
@@ -410,6 +410,18 @@ soc_info_t soc_info_table[] = {
 		.icache_fix   = true,
 		.watchdog     = &wd_v853_compat,
 	},{
+		.soc_id       = 0x1859, /* Allwinner D1/D1s/R528/T113-S3 */
+		.name         = "R528",
+		.spl_addr     = 0x20000,
+		.scratch_addr = 0x21000,
+		.thunk_addr   = 0x3a200, .thunk_size = 0x200,
+		.swap_buffers = v831_sram_swap_buffers,
+		.sram_size    = 160 * 1024,
+		.sid_base     = 0x03006000,
+		.sid_offset   = 0x200,
+		.icache_fix   = true,
+		.watchdog     = &wd_v853_compat,
+	},{
 		.swap_buffers = NULL /* End of the table */
 	}
 };

--- a/uart0-helloworld-sdboot.c
+++ b/uart0-helloworld-sdboot.c
@@ -141,6 +141,7 @@ enum sunxi_gpio_number {
 #define SUN5I_GPB_UART0         (2)
 #define SUN6I_GPH_UART0         (2)
 #define SUN8I_H3_GPA_UART0      (2)
+#define SUN8I_R528_GPE_UART0	(6)
 #define SUN8I_V3S_GPB_UART0	(3)
 #define SUN8I_V831_GPH_UART0	(5)
 #define SUN8I_V853_GPH_UART0	(5)
@@ -310,6 +311,7 @@ void soc_detection_init(void)
 #define soc_is_v3s()	(soc_id == 0x1681)
 #define soc_is_v831()	(soc_id == 0x1817)
 #define soc_is_v853()	(soc_id == 0x1886)
+#define soc_is_r528()	(soc_id == 0x1859)
 
 /* A10s and A13 share the same ID, so we need a little more effort on those */
 
@@ -396,7 +398,7 @@ void clock_init_uart(void)
 {
 	if (soc_is_h6() || soc_is_v831() || soc_is_h616())
 		clock_init_uart_h6();
-	else if (soc_is_r329() || soc_is_v853())
+	else if (soc_is_r329() || soc_is_v853() || soc_is_r528())
 		clock_init_uart_r329();
 	else
 		clock_init_uart_legacy();
@@ -410,7 +412,7 @@ void clock_init_uart(void)
 
 void gpio_init(void)
 {
-	if (soc_is_v853()) {
+	if (soc_is_v853() || soc_is_r528()) {
 		/* GPIO V2 */
 		pio_bank_size = 0x30;
 		pio_dat_off = 0x10;
@@ -478,6 +480,10 @@ void gpio_init(void)
 		sunxi_gpio_set_cfgpin(SUNXI_GPH(9), SUN8I_V853_GPH_UART0);
 		sunxi_gpio_set_cfgpin(SUNXI_GPH(10), SUN8I_V853_GPH_UART0);
 		sunxi_gpio_set_pull(SUNXI_GPH(10), SUNXI_GPIO_PULL_UP);
+	} else if (soc_is_r528()) {
+		sunxi_gpio_set_cfgpin(SUNXI_GPE(2), SUN8I_R528_GPE_UART0);
+		sunxi_gpio_set_cfgpin(SUNXI_GPE(3), SUN8I_R528_GPE_UART0);
+		sunxi_gpio_set_pull(SUNXI_GPE(3), SUNXI_GPIO_PULL_UP);
 	} else {
 		/* Unknown SoC */
 		while (1) {}
@@ -580,7 +586,7 @@ void bases_init(void)
 	} else if (soc_is_r329()) {
 		pio_base = R329_PIO_BASE;
 		uart0_base = R329_UART0_BASE;
-	} else if (soc_is_v853()) {
+	} else if (soc_is_v853() || soc_is_r528()) {
 		pio_base = V853_PIO_BASE;
 		uart0_base = R329_UART0_BASE;
 	} else {
@@ -629,6 +635,8 @@ int main(void)
 		uart0_puts("Allwinner V831!\n");
 	else if (soc_is_v853())
 		uart0_puts("Allwinner V853!\n");
+	else if (soc_is_r528())
+		uart0_puts("Allwinner R528/T113!\n");
 	else
 		uart0_puts("unknown Allwinner SoC!\n");
 

--- a/uart0-helloworld-sdboot.c
+++ b/uart0-helloworld-sdboot.c
@@ -143,6 +143,7 @@ enum sunxi_gpio_number {
 #define SUN8I_H3_GPA_UART0      (2)
 #define SUN8I_R528_GPE_UART0	(6)
 #define SUN8I_V3S_GPB_UART0	(3)
+#define SUN8I_V5_GPB_UART0	(2)
 #define SUN8I_V831_GPH_UART0	(5)
 #define SUN8I_V853_GPH_UART0	(5)
 #define SUN50I_H5_GPA_UART0     (2)
@@ -312,6 +313,7 @@ void soc_detection_init(void)
 #define soc_is_v831()	(soc_id == 0x1817)
 #define soc_is_v853()	(soc_id == 0x1886)
 #define soc_is_r528()	(soc_id == 0x1859)
+#define soc_is_v5()	(soc_id == 0x1721)
 
 /* A10s and A13 share the same ID, so we need a little more effort on those */
 
@@ -396,7 +398,7 @@ void clock_init_uart_r329(void)
 
 void clock_init_uart(void)
 {
-	if (soc_is_h6() || soc_is_v831() || soc_is_h616())
+	if (soc_is_h6() || soc_is_v831() || soc_is_h616() || soc_is_v5())
 		clock_init_uart_h6();
 	else if (soc_is_r329() || soc_is_v853() || soc_is_r528())
 		clock_init_uart_r329();
@@ -484,6 +486,10 @@ void gpio_init(void)
 		sunxi_gpio_set_cfgpin(SUNXI_GPE(2), SUN8I_R528_GPE_UART0);
 		sunxi_gpio_set_cfgpin(SUNXI_GPE(3), SUN8I_R528_GPE_UART0);
 		sunxi_gpio_set_pull(SUNXI_GPE(3), SUNXI_GPIO_PULL_UP);
+	} else if (soc_is_v5()) {
+		sunxi_gpio_set_cfgpin(SUNXI_GPB(9), SUN8I_V5_GPB_UART0);
+		sunxi_gpio_set_cfgpin(SUNXI_GPB(10), SUN8I_V5_GPB_UART0);
+		sunxi_gpio_set_pull(SUNXI_GPB(10), SUNXI_GPIO_PULL_UP);
 	} else {
 		/* Unknown SoC */
 		while (1) {}
@@ -580,7 +586,7 @@ int get_boot_device(void)
 
 void bases_init(void)
 {
-	if (soc_is_h6() || soc_is_v831() || soc_is_h616()) {
+	if (soc_is_h6() || soc_is_v831() || soc_is_h616() || soc_is_v5()) {
 		pio_base = H6_PIO_BASE;
 		uart0_base = H6_UART0_BASE;
 	} else if (soc_is_r329()) {
@@ -637,6 +643,8 @@ int main(void)
 		uart0_puts("Allwinner V853!\n");
 	else if (soc_is_r528())
 		uart0_puts("Allwinner R528/T113!\n");
+	else if (soc_is_v5())
+		uart0_puts("Allwinner V5!\n");
 	else
 		uart0_puts("unknown Allwinner SoC!\n");
 


### PR DESCRIPTION
This adds support for the Allwinner V5, which is close to the H6, but with 32-bit cores.
Also basic support for the R528/T113, which is the same SoC as the RISC-V D1 (even using the same SoC ID), but with that RISC-V core disabled. Proper D1 support requires much more work to support non-ARM code uploads.
Also includes uart0 hello world support for both SoCs.