### PR TITLE
uart0-helloworld-sdboot: add support for F1C100s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,10 +171,10 @@ jtag-loop.elf: jtag-loop.c jtag-loop.lds
 	$(CROSS_CC) -g $(ARM_ELF_FLAGS) $< -nostdlib -o $@ -T jtag-loop.lds -Wl,-N
 
 fel-sdboot.elf: fel-sdboot.S fel-sdboot.lds
-	$(CROSS_CC) -g $(ARM_ELF_FLAGS) $< -nostdlib -o $@ -T fel-sdboot.lds -Wl,-N
+	$(CROSS_CC) -march=armv5te -g $(ARM_ELF_FLAGS) $< -nostdlib -o $@ -T fel-sdboot.lds -Wl,-N
 
 uart0-helloworld-sdboot.elf: uart0-helloworld-sdboot.c uart0-helloworld-sdboot.lds
-	$(CROSS_CC) -g $(ARM_ELF_FLAGS) $< -nostdlib -o $@ -T uart0-helloworld-sdboot.lds -Wl,-N
+	$(CROSS_CC) -march=armv5te -g $(ARM_ELF_FLAGS) $< -nostdlib -o $@ -T uart0-helloworld-sdboot.lds -Wl,-N
 
 boot_head_sun3i.elf: boot_head.S boot_head.lds
 	$(CROSS_CC) -g $(ARM_ELF_FLAGS) $< -nostdlib -o $@ -T boot_head.lds -Wl,-N -DMACHID=0x1094


### PR DESCRIPTION
The F1C100s series of SoCs has some subtle differences in its UART setup:
- The UART is at a previously unused address.
- The base clock is not APB2, but APB1.
- The input clock is not 24 MHz, but CPU clock / 2 / 2.
- The clock and reset gates are different bits at different addresses.

Add support for all those differences, tied to the F1C100s SoC ID.

Signed-off-by: Andre Przywara <osp@andrep.de>