### PR TITLE
fel: Introduce 'sid-dump'

### DIFF
--- a/fel_lib.c
+++ b/fel_lib.c
@@ -610,6 +610,15 @@ bool fel_get_sid_root_key(feldev_handle *dev, uint32_t *result,
 	return true;
 }
 
+bool fel_get_sid(feldev_handle *dev, uint32_t *result, uint32_t offset,
+		 size_t count)
+{
+	fel_readl_n(dev, dev->soc_info->sid_base
+		    + dev->soc_info->sid_offset + offset, result, count);
+
+	return true;
+}
+
 /* general functions, "FEL device" management */
 
 static int feldev_get_endpoint(feldev_handle *dev)

--- a/fel_lib.h
+++ b/fel_lib.h
@@ -80,6 +80,8 @@ void fel_clrsetbits_le32(feldev_handle *dev,
 /* retrieve SID root key */
 bool fel_get_sid_root_key(feldev_handle *dev, uint32_t *result,
 			  bool force_workaround);
+bool fel_get_sid(feldev_handle *dev, uint32_t *result, uint32_t offset,
+		 size_t count);
 
 bool aw_fel_remotefunc_prepare(feldev_handle *dev,
 			       size_t                stack_size,

--- a/soc_info.c
+++ b/soc_info.c
@@ -187,6 +187,19 @@ const watchdog_info wd_v853_compat = {
 	.reg_mode_value = 0x16aa0001,
 };
 
+const sid_section r40_sid_maps[] = {
+	SID_SECTION("chipid",	0x00, 128),
+	SID_SECTION("in",	0x10, 256),
+	SID_SECTION("ssk",	0x30, 128),
+	SID_SECTION("thermal",	0x40,  32),
+	SID_SECTION("ft_zone",	0x44,  64),
+	SID_SECTION("tvout",	0x4c, 128),
+	SID_SECTION("rssk",	0x5c, 256),
+	SID_SECTION("hdcp_hash",0x7c, 128),
+	SID_SECTION("reserved",	0x90, 896),
+	SID_SECTION(NULL,	0,      0),
+};
+
 soc_info_t soc_info_table[] = {
 	{
 		.soc_id       = 0x1623, /* Allwinner A10 */
@@ -335,6 +348,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 48 * 1024,
 		.sid_base     = 0x01C1B000,
 		.sid_offset   = 0x200,
+		.sid_sections = r40_sid_maps,
 		.watchdog     = &wd_a10_compat,
 	},{
 		.soc_id       = 0x1719, /* Allwinner A63 */

--- a/soc_info.h
+++ b/soc_info.h
@@ -62,6 +62,21 @@ typedef struct {
 } watchdog_info;
 
 /*
+ * sunxi sid sections
+ */
+typedef struct {
+	const char	*name;
+	uint32_t	offset;
+	uint32_t	size_bits;
+} sid_section;
+
+#define SID_SECTION(_name, _offset, _size_bits) {	\
+	.name = _name,					\
+	.offset = _offset,				\
+	.size_bits = _size_bits,			\
+}
+
+/*
  * Each SoC variant may have its own list of memory buffers to be exchanged
  * and the information about the placement of the thunk code, which handles
  * the transition of execution from the BROM FEL code to the U-Boot SPL and
@@ -110,6 +125,7 @@ typedef struct {
 	uint32_t           mmu_tt_addr;  /* MMU translation table address */
 	uint32_t           sid_base;     /* base address for SID registers */
 	uint32_t           sid_offset;   /* offset for SID_KEY[0-3], "root key" */
+	const sid_section *sid_sections; /* sid memory maps */
 	uint32_t           rvbar_reg;    /* MMIO address of RVBARADDR0_L register */
 	const watchdog_info *watchdog;   /* Used for reset */
 	bool               sid_fix;      /* Use SID workaround (read via register) */


### PR DESCRIPTION
A sample output from allwinner T3:

```console
$ ./sunxi-fel sid-dump
chipid          1300000c 02404700 79350400 5c761e0c
in              00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
ssk             00000000 00000000 00000000 00000000
thermal         08320834
ft_zone         00000000 00000000
tvout           010002b0 00f7029b 00f9029f 00fb02a5
rssk            00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
hdcp_hash       00000000 00000000 00000000 00000000
reserved        00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
                00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
                00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
                00000000 00000000 00000000 00000000
```