### PR TITLE
Complete SID dump

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -1273,6 +1273,9 @@ void usage(const char *cmd) {
 		"	echo-gauge \"some text\"		Update prompt/caption for gauge output\n"
 		"	ver[sion]			Show BROM version\n"
 		"	sid				Retrieve and output 128-bit SID key\n"
+		"	sid-registers			Retrieve and output 128-bit SID key,\n"
+		"					using the MMIO register read method\n"
+		"	sid-dump			Dump the content of all the SID eFuses\n"
 		"	clear address length		Clear memory\n"
 		"	fill address length value	Fill memory\n"
 		, cmd);

--- a/fel.c
+++ b/fel.c
@@ -433,7 +433,7 @@ void aw_fel_print_sid(feldev_handle *dev, bool force_workaround)
 		pr_info("SID key (e-fuses) at 0x%08X\n",
 			soc_info->sid_base + soc_info->sid_offset);
 	}
-	fel_get_sid_root_key(dev, key, force_workaround);
+	fel_read_sid(dev, key, 0, sizeof(key), force_workaround);
 
 	/* output SID in "xxxxxxxx:xxxxxxxx:xxxxxxxx:xxxxxxxx" format */
 	for (unsigned i = 0; i <= 3; i++)
@@ -454,7 +454,7 @@ void aw_fel_dump_sid(feldev_handle *dev)
 	for (const sid_section *s = soc_info->sid_sections; s->name; s++) {
 		uint32_t count = s->size_bits / 32;
 
-		if (!fel_get_sid(dev, buffer, s->offset, count)) {
+		if (fel_read_sid(dev, buffer, s->offset, count * 4, false)) {
 			fprintf(stderr, "Read sid:%s failed\n", s->name);
 			return;
 		}

--- a/fel_lib.c
+++ b/fel_lib.c
@@ -551,9 +551,10 @@ void fel_clrsetbits_le32(feldev_handle *dev,
 static void fel_get_sid_registers(feldev_handle *dev, uint32_t *result)
 {
 	uint32_t arm_code[] = {
-		htole32(0xe59f0040), /*    0:  ldr   r0, [pc, #64]           */
-		htole32(0xe3a01000), /*    4:  mov   r1, #0                  */
-		htole32(0xe28f303c), /*    8:  add   r3, pc, #60             */
+		/* <sid_read_root_key>: */
+		htole32(0xe59f0044), /*    0:  ldr   r0, [pc, #68]           */
+		htole32(0xe59f1044), /*    4:  ldr   r1, [pc, #68]           */
+		htole32(0xe28f3048), /*    8:  add   r3, pc, #72             */
 		/* <sid_read_loop>: */
 		htole32(0xe1a02801), /*    c:  lsl   r2, r1, #16             */
 		htole32(0xe3822b2b), /*   10:  orr   r2, r2, #44032          */
@@ -564,14 +565,20 @@ static void fel_get_sid_registers(feldev_handle *dev, uint32_t *result)
 		htole32(0xe3120002), /*   20:  tst   r2, #2                  */
 		htole32(0x1afffffc), /*   24:  bne   1c <sid_read_wait>      */
 		htole32(0xe5902060), /*   28:  ldr   r2, [r0, #96]           */
-		htole32(0xe7832001), /*   2c:  str   r2, [r3, r1]            */
+		htole32(0xe4832004), /*   2c:  str   r2, [r3], #4            */
 		htole32(0xe2811004), /*   30:  add   r1, r1, #4              */
-		htole32(0xe3510010), /*   34:  cmp   r1, #16                 */
-		htole32(0x3afffff3), /*   38:  bcc   c <sid_read_loop>       */
-		htole32(0xe3a02000), /*   3c:  mov   r2, #0                  */
-		htole32(0xe5802040), /*   40:  str   r2, [r0, #64]           */
-		htole32(0xe12fff1e), /*   44:  bx    lr                      */
+		htole32(0xe59f2018), /*   34:  ldr   r2, [pc, #24]           */
+		htole32(0xe1510002), /*   38:  cmp   r1, r2                  */
+		htole32(0x3afffff2), /*   3c:  bcc   c <sid_read_loop>       */
+		htole32(0xe3a02000), /*   40:  mov   r2, #0                  */
+		htole32(0xe5802040), /*   44:  str   r2, [r0, #64]           */
+		htole32(0xe12fff1e), /*   48:  bx    lr                      */
+		/* <sid_base>: */
 		htole32(dev->soc_info->sid_base), /* SID base addr */
+		/* <offset>: */
+		htole32(0),			/* first word to read */
+		/* <end>: */
+		htole32(16),			/* where to stop to read */
 		/* retrieved SID values go here */
 	};
 	/* write and execute code */

--- a/fel_lib.h
+++ b/fel_lib.h
@@ -77,11 +77,9 @@ void fel_clrsetbits_le32(feldev_handle *dev,
 #define fel_setbits_le32(dev, addr, value) \
 	fel_clrsetbits_le32(dev, addr, 0, value)
 
-/* retrieve SID root key */
-bool fel_get_sid_root_key(feldev_handle *dev, uint32_t *result,
-			  bool force_workaround);
-bool fel_get_sid(feldev_handle *dev, uint32_t *result, uint32_t offset,
-		 size_t count);
+int fel_read_sid(feldev_handle *dev, uint32_t *result,
+		 unsigned int offset, unsigned int length,
+		 bool force_workaround);
 
 bool aw_fel_remotefunc_prepare(feldev_handle *dev,
 			       size_t                stack_size,

--- a/soc_info.c
+++ b/soc_info.c
@@ -187,7 +187,7 @@ const watchdog_info wd_v853_compat = {
 	.reg_mode_value = 0x16aa0001,
 };
 
-const sid_section r40_sid_maps[] = {
+static const sid_section r40_sid_maps[] = {
 	SID_SECTION("chipid",	0x00, 128),
 	SID_SECTION("in",	0x10, 256),
 	SID_SECTION("ssk",	0x30, 128),
@@ -198,6 +198,66 @@ const sid_section r40_sid_maps[] = {
 	SID_SECTION("hdcp_hash",0x7c, 128),
 	SID_SECTION("reserved",	0x90, 896),
 	SID_SECTION(NULL,	0,      0),
+};
+
+static const sid_section h3_sid_maps[] = {
+	SID_SECTION("chipid",		0x00, 128),
+	SID_SECTION("oem_program",	0x10,  32),
+	SID_SECTION("nv1",	 	0x14,  32),
+	SID_SECTION("nv2",	 	0x18,  64),
+	SID_SECTION("rsakey_hash",	0x20, 160),
+	SID_SECTION("thermal",		0x34,  64),
+	SID_SECTION("renewability",	0x3c,  64),
+	SID_SECTION("huk",		0x44, 256),
+	SID_SECTION("rotpk_hash",	0x64, 256),
+	SID_SECTION("ssk",		0x84, 128),
+	SID_SECTION("rssk",		0x94, 256),
+	SID_SECTION("hdcp_hash",	0xb4, 128),
+	SID_SECTION("ek_hash",		0xc4, 128),
+	SID_SECTION("sn",		0xd4, 192),
+	SID_SECTION("nv2_backup",	0xec,  64),
+	SID_SECTION("lcjs",		0xf4,  32),
+	SID_SECTION("debug",		0xf8,  32),
+	SID_SECTION("chip_config",	0xfc,  32),
+	SID_SECTION(NULL,	0,      0),
+};
+
+static const sid_section h6_sid_maps[] = {
+	SID_SECTION("chipid",		 0x00, 128),
+	SID_SECTION("brom_config", 	 0x10,  32),
+	SID_SECTION("thermal",		 0x14,  64),
+	SID_SECTION("tf_zone",		 0x1c, 128),
+	SID_SECTION("oem_program",	 0x2c,  96),
+	SID_SECTION("mac-addr",		 0x38,  64),
+	SID_SECTION("write_protect",	 0x40,  32),
+	SID_SECTION("read-protect",	 0x44,  32),
+	SID_SECTION("lcjs",		 0x48,  32),
+	SID_SECTION("attr",		 0x4c,  32),
+	SID_SECTION("huk",		 0x50,  96),
+	SID_SECTION("vendor_id",	 0x5c,  32),
+	SID_SECTION("huk2",		 0x60, 128),
+	SID_SECTION("rotpk_hash",	 0x70, 256),
+	SID_SECTION("ssk",		 0x90, 128),
+	SID_SECTION("rssk",		 0xa0, 256),
+	SID_SECTION("hdcp_hash",	 0xc0, 128),
+	SID_SECTION("ek_hash",	 	 0xd0, 128),
+	SID_SECTION("sn", 		 0xe0, 192),
+	SID_SECTION("nv1",	 	 0xf8,  32),
+	SID_SECTION("nv2",	 	 0xfc, 224),
+	SID_SECTION("hdcp_pkf",	 	0x118, 128),
+	SID_SECTION("hdcp_duk",	 	0x128, 128),
+	SID_SECTION("backup_key", 	0x138, 576),
+	SID_SECTION("sck0",	 	0x180, 256),
+	SID_SECTION("sck0_mask", 	0x1a0, 256),
+	SID_SECTION("sck1",	 	0x1c0, 256),
+	SID_SECTION("sck1_mask", 	0x1e0, 256),
+	SID_SECTION(NULL,	0,      0)
+};
+
+/* Placeholder for SoCs without a known SID map */
+static const sid_section generic_2k_sid_maps[] = {
+	SID_SECTION("chipid",		0x00,  128),
+	SID_SECTION("unknown",		0x10, 1920),
 };
 
 soc_info_t soc_info_table[] = {
@@ -229,6 +289,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = a10_a13_a20_sram_swap_buffers,
 		.sram_size    = 48 * 1024,
 		.sid_base     = 0x01C23800,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_a10_compat,
 	},{
 		.soc_id       = 0x1650, /* Allwinner A23 */
@@ -238,6 +299,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = ar100_abusing_sram_swap_buffers,
 		.sram_size    = 64 * 1024,
 		.sid_base     = 0x01C23800,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1633, /* Allwinner A31 */
@@ -255,6 +317,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = ar100_abusing_sram_swap_buffers,
 		.sram_size    = 32 * 1024,
 		.sid_base     = 0x01C23800,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1689, /* Allwinner A64 */
@@ -266,6 +329,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 140 * 1024,
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
+		.sid_sections = h3_sid_maps,
 		.rvbar_reg    = 0x017000A0,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
@@ -280,6 +344,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 40 * 1024,
 		.sid_base     = 0X01C0E000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_a80,
 	},{
 		.soc_id       = 0x1663, /* Allwinner F1C100s (all new sun3i?) */
@@ -300,6 +365,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 32 * 1024,
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1680, /* Allwinner H3, H2+ */
@@ -312,6 +378,7 @@ soc_info_t soc_info_table[] = {
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
 		.sid_fix      = true,
+		.sid_sections = h3_sid_maps,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
 		.watchdog     = &wd_h3_compat,
@@ -324,6 +391,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = a10_a13_a20_sram_swap_buffers,
 		.sram_size    = 60 * 1024,
 		.sid_base     = 0x01C23800,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1718, /* Allwinner H5 */
@@ -335,6 +403,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 140 * 1024,
 		.sid_base     = 0x01C14000,
 		.sid_offset   = 0x200,
+		.sid_sections = h3_sid_maps,
 		.rvbar_reg    = 0x017000A0,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
@@ -360,6 +429,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 144 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.rvbar_reg    = 0x09010040,
 		.watchdog     = &wd_h6_compat,
 	},{
@@ -372,6 +442,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 144 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = h6_sid_maps,
 		.rvbar_reg    = 0x09010040,
 		/* Check L.NOP in the OpenRISC reset vector */
 		.needs_smc_workaround_if_zero_word_at_addr = 0x100004,
@@ -386,6 +457,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 228 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_h6_compat,
 	},{
 		.soc_id       = 0x1817, /* Allwinner V831 */
@@ -397,6 +469,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 228 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_h6_compat,
 	},{
 		.soc_id       = 0x1823, /* Allwinner H616 */
@@ -408,6 +481,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 207 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.rvbar_reg    = 0x09010040,
 		.watchdog     = &wd_h6_compat,
 	},{
@@ -421,6 +495,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 1856 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.rvbar_reg    = 0x08100040,
 		.watchdog     = &wd_h6_compat,
 	},{
@@ -433,6 +508,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 132 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.icache_fix   = true,
 		.watchdog     = &wd_v853_compat,
 	},{
@@ -445,6 +521,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 160 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.icache_fix   = true,
 		.watchdog     = &wd_v853_compat,
 	},{
@@ -457,6 +534,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 136 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_h6_compat,
 	},{
 		.swap_buffers = NULL /* End of the table */

--- a/sunxi-fel.1
+++ b/sunxi-fel.1
@@ -116,6 +116,13 @@ Request a warm reset of the core, starting execution in the 64-bit AArch64
 execution state, at <address>.
 .RE
 .PP
+.B wdreset
+.RS 4
+Reset the device by triggering the watchdog with the shortest possible period.
+This will reset the whole SoC, including all on-SoC peripherals, but might not
+affect on-board devices like PMICs or PHYs.
+.RE
+.PP
 .B memmove <dest> <source> <size>
 .RS 4
 Copy <size> bytes within device memory, from <source> to <dest>.
@@ -203,10 +210,18 @@ number, which should be unique to each chip (although there have been reports
 of same SIDs for particular batches of chips).
 .RE
 .PP
-.B sid-register
+.B sid-registers
 .RS 4
 As the "sid" command above, but use the alternative MMIO register access method
-on the device. Some SoCs require this method for reliable results.
+on the device. There are SoCs that require this method due to bugs in the SID
+implementation, those known will automatically choose this workaround when using
+the "sid" command. This command here is to test new SoCs for compliance.
+.RE
+.PP
+.B sid-dump
+.RS 4
+Read the entire SID eFuses array and dump its content. For SoCs with a known
+eFuses layout, this will annotate the known regions.
 .RE
 .PP
 .B clear <address> <length>

--- a/thunks/sid_read_root.S
+++ b/thunks/sid_read_root.S
@@ -42,7 +42,7 @@ sid_key_index	.req	r1
 
 sid_read_root_key:
 	ldr	SID_BASE, sid_base
-	mov	sid_key_index, #0
+	ldr	sid_key_index, offset
 	adr	r3, sid_result			/* result pointer */
 sid_read_loop:
 	mov	r2, sid_key_index, lsl #16	/* PG_INDEX value */
@@ -55,10 +55,11 @@ sid_read_wait:
 	bne	sid_read_wait		/* loop while bit 1 still set */
 
 	ldr	r2, [SID_BASE, #SID_RDKEY]	/* read SID key value */
-	str	r2, [r3, sid_key_index]		/* store SID value */
+	str	r2, [r3], #4			/* store SID value */
 
 	add	sid_key_index, #4
-	cmp	sid_key_index, #16
+	ldr	r2, end
+	cmp	sid_key_index, r2
 	blo	sid_read_loop		/* loop while (sid_key_index < 0x10) */
 
 	mov	r2, #0
@@ -66,7 +67,6 @@ sid_read_wait:
 	bx	lr
 
 sid_base:	.word 0
-sid_result:	.word 0 /* receives the four "root key" 32-bit words */
-		.word 0
-		.word 0
-		.word 0
+offset:		.word 0
+end:		.word 0
+sid_result:	/* receives the values read from the SID registers */

--- a/thunks/sid_read_root.h
+++ b/thunks/sid_read_root.h
@@ -1,7 +1,7 @@
 		/* <sid_read_root_key>: */
-		htole32(0xe59f0040), /*    0:  ldr   r0, [pc, #64]           */
-		htole32(0xe3a01000), /*    4:  mov   r1, #0                  */
-		htole32(0xe28f303c), /*    8:  add   r3, pc, #60             */
+		htole32(0xe59f0044), /*    0:  ldr   r0, [pc, #68]           */
+		htole32(0xe59f1044), /*    4:  ldr   r1, [pc, #68]           */
+		htole32(0xe28f3048), /*    8:  add   r3, pc, #72             */
 		/* <sid_read_loop>: */
 		htole32(0xe1a02801), /*    c:  lsl   r2, r1, #16             */
 		htole32(0xe3822b2b), /*   10:  orr   r2, r2, #44032          */
@@ -12,13 +12,17 @@
 		htole32(0xe3120002), /*   20:  tst   r2, #2                  */
 		htole32(0x1afffffc), /*   24:  bne   1c <sid_read_wait>      */
 		htole32(0xe5902060), /*   28:  ldr   r2, [r0, #96]           */
-		htole32(0xe7832001), /*   2c:  str   r2, [r3, r1]            */
+		htole32(0xe4832004), /*   2c:  str   r2, [r3], #4            */
 		htole32(0xe2811004), /*   30:  add   r1, r1, #4              */
-		htole32(0xe3510010), /*   34:  cmp   r1, #16                 */
-		htole32(0x3afffff3), /*   38:  bcc   c <sid_read_loop>       */
-		htole32(0xe3a02000), /*   3c:  mov   r2, #0                  */
-		htole32(0xe5802040), /*   40:  str   r2, [r0, #64]           */
-		htole32(0xe12fff1e), /*   44:  bx    lr                      */
+		htole32(0xe59f2018), /*   34:  ldr   r2, [pc, #24]           */
+		htole32(0xe1510002), /*   38:  cmp   r1, r2                  */
+		htole32(0x3afffff2), /*   3c:  bcc   c <sid_read_loop>       */
+		htole32(0xe3a02000), /*   40:  mov   r2, #0                  */
+		htole32(0xe5802040), /*   44:  str   r2, [r0, #64]           */
+		htole32(0xe12fff1e), /*   48:  bx    lr                      */
 		/* <sid_base>: */
-		htole32(0x00000000), /*   48:  .word 0x00000000              */
-		/* <sid_result>: */
+		htole32(0x00000000), /*   4c:  .word 0x00000000              */
+		/* <offset>: */
+		htole32(0x00000000), /*   50:  .word 0x00000000              */
+		/* <end>: */
+		htole32(0x00000000), /*   54:  .word 0x00000000              */


### PR DESCRIPTION
Add some bits that were missing from the just merged sid-dump feature:
- support for the H3 register access work around
- maps for other SoCs
- documentation
@qianfan-Zhao @smaeul please have a look!