### PR TITLE
fel: sid: fix segfault with default section map

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -258,6 +258,7 @@ static const sid_section h6_sid_maps[] = {
 static const sid_section generic_2k_sid_maps[] = {
 	SID_SECTION("chipid",		0x00,  128),
 	SID_SECTION("unknown",		0x10, 1920),
+	SID_SECTION(NULL, 0, 0),
 };
 
 soc_info_t soc_info_table[] = {


### PR DESCRIPTION
The `generic_2k_sid_maps`, describing the SID sections for chips where we don't have any specific information yet, was missing the terminating NULL section, so we would run off into to woods, beyond the array limit. This would most commonly result in a segfault:
```
$ sunxi-fel sid-dump
....
                00000000 00000000 00000000 00000000
Segmentation fault (core dumped)
```

Add the NULL sentinel to terminate the loop correctly.