### PR TITLE
fel: h616: support alternative die variant

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -484,6 +484,8 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.sid_sections = generic_2k_sid_maps,
 		.rvbar_reg    = 0x09010040,
+		.rvbar_reg_alt= 0x08100040,
+		.ver_reg      = 0x03000024,
 		.watchdog     = &wd_h6_compat,
 	},{
 		.soc_id       = 0x1851, /* Allwinner R329 */

--- a/soc_info.h
+++ b/soc_info.h
@@ -127,6 +127,8 @@ typedef struct {
 	uint32_t           sid_offset;   /* offset for SID_KEY[0-3], "root key" */
 	const sid_section *sid_sections; /* sid memory maps */
 	uint32_t           rvbar_reg;    /* MMIO address of RVBARADDR0_L register */
+	uint32_t           rvbar_reg_alt;/* alternative MMIO address of RVBARADDR0_L register */
+	uint32_t           ver_reg;      /* MMIO address of "Version Register" */
 	const watchdog_info *watchdog;   /* Used for reset */
 	bool               sid_fix;      /* Use SID workaround (read via register) */
 	/* Use I$ workaround (disable I$ before first write to prevent stale thunk */


### PR DESCRIPTION
The Allwinner H616 ships in at least two die variants, sometime under a different name (H618, T507), but sometimes labeled as a normal "H616". The die variants differ in their CPU cluster control subsystem, which affects the location of the RVBAR shadow register used to reset the core into 64-bit mode. We use that in the "reset64" command, but also as part of the boot process using the "uboot" command, on ARMv8 cores.

Add code to detect the die variant by reading the VER_REG MMIO register, where the original die reports 0x00 in the lower 8 bits, but the newer die variants apparently 0x02. In the latter case let the aw_rmr_request() function use the alternative RVBAR address to do the 64-bit switch. This matches what we do in U-Boot and Trusted Firmware.