### PR TITLE
fel: sid: fix stack overflow while reading from SID

### DIFF
--- a/fel_lib.c
+++ b/fel_lib.c
@@ -623,7 +623,7 @@ int fel_read_sid(feldev_handle *dev, uint32_t *result,
 	else
 		/* Read SID directly from memory */
 		fel_readl_n(dev, soc->sid_base + soc->sid_offset + offset,
-			    result, length);
+			    result, length / 4);
 	return 0;
 }
 


### PR DESCRIPTION
When reading from the SID device using the normal memory access method, we upload our "readl" routine (via fel_readl_n()), which expects a number of *words* to read. However length is given in *bytes*, so we read four times as much, and overflow our key buffer, clobbering the return address. This is typically fatal:
```
$ ./sunxi-fel sid
02c05200:12345678:34567890:76543210
Segmentation fault (core dumped)
$

```
Fix this by giving the number of (32-bit) words instead. We already checked that length is a multiple of 4, so we can just divide.