### PR TITLE
fel: Add support for allwinner T7

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -285,6 +285,29 @@ static const sid_section h6_sid_maps[] = {
 	SID_SECTION(NULL,	0,      0)
 };
 
+static const sid_section t7_sid_maps[] = {
+	SID_SECTION("chipid",		 0x00, 128),
+	SID_SECTION("brom_config",	 0x10,  32),
+	SID_SECTION("thermal",		 0x14,  96),
+	SID_SECTION("tf_zone",		 0x20, 128),
+	SID_SECTION("oem",		 0x30, 128),
+	SID_SECTION("jtag-security",	 0x48,  32),
+	SID_SECTION("jtag-attr",	 0x4c,  32),
+	SID_SECTION("in",		 0x50, 192),
+	SID_SECTION("operator-id",	 0x68,  32),
+	SID_SECTION("id",		 0x6c,  32),
+	SID_SECTION("rotpk",		 0x70, 256),
+	SID_SECTION("ssk",		 0x90, 128),
+	SID_SECTION("rssk",		 0xa0, 256),
+	SID_SECTION("reserved",		 0xc0, 128),
+	SID_SECTION("ek_hash",	 	 0xd0, 128),
+	SID_SECTION("sn", 		 0xe0, 192),
+	SID_SECTION("nv1",	 	 0xf8,  32),
+	SID_SECTION("nv2",	 	 0xfc, 224),
+	SID_SECTION("reserved2", 	0x118, 320),
+	SID_SECTION(NULL,	0,      0)
+};
+
 /* Placeholder for SoCs without a known SID map */
 static const sid_section generic_2k_sid_maps[] = {
 	SID_SECTION("chipid",		0x00,  128),
@@ -435,7 +458,7 @@ soc_info_t soc_info_table[] = {
 		.sram_size    = 184 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
-		.sid_sections = generic_2k_sid_maps,
+		.sid_sections = t7_sid_maps,
 		.watchdog     = &wd_h6_compat,
 	},{
 		.soc_id       = 0x1718, /* Allwinner H5 */

--- a/soc_info.c
+++ b/soc_info.c
@@ -113,6 +113,24 @@ sram_swap_buffers h6_sram_swap_buffers[] = {
 };
 
 /*
+ * T7 SRAM layout:
+ *
+ * SRAM A1: 0x0002_0000 - 0x0002_7fff,  32K contains stacks
+ * SRAM  C: 0x0002_8000 - 0x0004_ffff, 160K full access
+ * SRAM A2: 0x0010_0000 - 0x0010_3fff,  16K OpenRISC
+ *          0x0010_4000 - 0x0011_ffff, 112K full access
+ */
+sram_swap_buffers t7_sram_swap_buffers[] = {
+	/* 0x21C00-0x21FFF (IRQ stack) */
+	{ .buf1 = 0x21C00, .buf2 = 0x4e400, .size = 0x0400 },
+	/* 0x25C00-0x26FFF (Stack) */
+	{ .buf1 = 0x25C00, .buf2 = 0x4e800, .size = 0x1400 },
+	/* 0x27C00-0x27FFF (Something important) */
+	{ .buf1 = 0x27C00, .buf2 = 0x4fc00, .size = 0x0400 },
+	{ .size = 0 }  /* End of the table */
+};
+
+/*
  * V831 has 96KiB SRAM A1 at 0x20000 where the SPL has to be loaded to.
  * SRAM C is continuous with SRAM A1, and both SRAMs are tried to be used
  * by BROM. Memory space is allocated both from the start of SRAM A1 and
@@ -407,6 +425,18 @@ soc_info_t soc_info_table[] = {
 		.sid_base     = 0x01C23800,
 		.sid_sections = generic_2k_sid_maps,
 		.watchdog     = &wd_h3_compat,
+	},{
+		.soc_id       = 0x1708, /* Allwinner T7 */
+		.name         = "T7",
+		.spl_addr     = 0x20000,
+		.scratch_addr = 0x21000,
+		.thunk_addr   = 0x4e200, .thunk_size = 0x200,
+		.swap_buffers = t7_sram_swap_buffers,
+		.sram_size    = 184 * 1024,
+		.sid_base     = 0x03006000,
+		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
+		.watchdog     = &wd_h6_compat,
 	},{
 		.soc_id       = 0x1718, /* Allwinner H5 */
 		.name         = "H5",

--- a/uart0-helloworld-sdboot.c
+++ b/uart0-helloworld-sdboot.c
@@ -313,6 +313,7 @@ void soc_detection_init(void)
 #define soc_is_h616()	(soc_id == 0x1823)
 #define soc_is_r329()	(soc_id == 0x1851)
 #define soc_is_r40()	(soc_id == 0x1701)
+#define soc_is_t7()	(soc_id == 0x1708)
 #define soc_is_v3s()	(soc_id == 0x1681)
 #define soc_is_v831()	(soc_id == 0x1817)
 #define soc_is_v853()	(soc_id == 0x1886)
@@ -419,7 +420,7 @@ void clock_init_uart_r329(void)
 void clock_init_uart(void)
 {
 	if (soc_is_h6() || soc_is_v831() || soc_is_h616() || soc_is_v5() ||
-	    soc_is_a63())
+	    soc_is_a63() || soc_is_t7())
 		clock_init_uart_h6();
 	else if (soc_is_r329() || soc_is_v853() || soc_is_r528())
 		clock_init_uart_r329();
@@ -469,7 +470,7 @@ void gpio_init(void)
 		sunxi_gpio_set_cfgpin(SUNXI_GPH(20), SUN6I_GPH_UART0);
 		sunxi_gpio_set_cfgpin(SUNXI_GPH(21), SUN6I_GPH_UART0);
 		sunxi_gpio_set_pull(SUNXI_GPH(21), SUNXI_GPIO_PULL_UP);
-	} else if (soc_is_a64()) {
+	} else if (soc_is_a64() || soc_is_t7()) {
 		sunxi_gpio_set_cfgpin(SUNXI_GPB(8), SUN50I_A64_GPB_UART0);
 		sunxi_gpio_set_cfgpin(SUNXI_GPB(9), SUN50I_A64_GPB_UART0);
 		sunxi_gpio_set_pull(SUNXI_GPB(9), SUNXI_GPIO_PULL_UP);
@@ -624,7 +625,7 @@ int get_boot_device(void)
 void bases_init(void)
 {
 	if (soc_is_h6() || soc_is_v831() || soc_is_h616() || soc_is_v5() ||
-	    soc_is_a63()) {
+	    soc_is_a63() || soc_is_t7()) {
 		pio_base = H6_PIO_BASE;
 		uart0_base = H6_UART0_BASE;
 	} else if (soc_is_r329()) {
@@ -686,6 +687,8 @@ int main(void)
 		uart0_puts("Allwinner V853!\n");
 	else if (soc_is_r528())
 		uart0_puts("Allwinner R528/T113!\n");
+	else if (soc_is_t7())
+		uart0_puts("Allwinner T7!\n");
 	else if (soc_is_v5())
 		uart0_puts("Allwinner V5!\n");
 	else if (soc_is_suniv())


### PR DESCRIPTION
uart0-helloworld-sdcard can work with this patch:

```console
./sunxi-fel --verbose spl uart0-helloworld-sdboot.sunxi
Stack pointers: sp_irq=0x00022000, sp=0x00025E08
MMU is not enabled by BROM
=> Executing the SPL... done.
```

And next is the uart console's log:

```
Hello from Allwinner T7!
Returning back to FEL.
```