### PR TITLE
A523 FEL fixes

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -180,6 +180,10 @@ sram_swap_buffers f1c100s_sram_swap_buffers[] = {
 	{ .size = 0 }  /* End of the table */
 };
 
+sram_swap_buffers a523_sram_swap_buffers[] = {
+	{ .buf1 = 0x45000, .buf2 = 0x40200, .size = 0x0400 },
+	{ .size = 0 }  /* End of the table */
+};
 /*
  * Some SoCs put both stacks, BSS and data segments at the end of a comparably
  * large SRAM, so we don't need to move anything around.
@@ -608,11 +612,11 @@ soc_info_t soc_info_table[] = {
 	},{
 		.soc_id       = 0x1890, /* Allwinner A523 */
 		.name         = "A523",
-		.spl_addr     = 0x20000,
-		.scratch_addr = 0x21000,
-		.thunk_addr   = 0x43e00, .thunk_size = 0x200,
-		.swap_buffers = no_sram_swap_buffers,
-		.sram_size    = 144 * 1024,
+		.spl_addr     = 0x44000,
+		.scratch_addr = 0x45000,
+		.thunk_addr   = 0x40000, .thunk_size = 0x200,
+		.swap_buffers = a523_sram_swap_buffers,
+		.sram_size    = 96 * 1024,
 		.sid_base     = 0x03006000,
 		.sid_offset   = 0x200,
 		.sid_sections = generic_2k_sid_maps,

--- a/soc_info.c
+++ b/soc_info.c
@@ -617,6 +617,7 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.sid_sections = generic_2k_sid_maps,
 		.rvbar_reg    = 0x08000040,
+		.icache_fix   = true,
 		.watchdog     = &wd_a523_compat,
 	},{
 		.swap_buffers = NULL /* End of the table */


### PR DESCRIPTION
While playing with a proper A523 (T527, really) devboard, I noticed some issues with the FEL support: We need to disable the I-cache, to allow uploading *and* executing code via FEL.
Also the load and buffer addresses are not ideal: the BROM actually loads any MMC payload somewhere else, so we need to follow suit here to keep a single SPL image, for loading via both SD card/eMMC/SPI and via FEL.