### PR TITLE
fel-lib: Fix parsing scratchpad field

### DIFF
--- a/fel_lib.c
+++ b/fel_lib.c
@@ -201,7 +201,7 @@ static void aw_fel_get_version(feldev_handle *dev, struct aw_fel_version *buf)
 	buf->soc_id = (le32toh(buf->soc_id) >> 8) & 0xFFFF;
 	buf->unknown_0a = le32toh(buf->unknown_0a);
 	buf->protocol = le32toh(buf->protocol);
-	buf->scratchpad = le16toh(buf->scratchpad);
+	buf->scratchpad = le32toh(buf->scratchpad);
 	buf->pad[0] = le32toh(buf->pad[0]);
 	buf->pad[1] = le32toh(buf->pad[1]);
 }


### PR DESCRIPTION
Field has 32 bits, not 16, as it is currently handled. This fixes scratchpad address print when using "sunxi-fel ver" command on A523. Before it printed "0x1500" and afterwards "0x61500", which makes much more sense and it was verified by BROM disassembly.