### PR TITLE
ADD: Basic soc info for H713 chip. Starting point.

### DIFF
--- a/soc_info.c
+++ b/soc_info.c
@@ -577,6 +577,21 @@ soc_info_t soc_info_table[] = {
 		.rvbar_reg    = 0x08100040,
 		.watchdog     = &wd_h6_compat,
 	},{
+		.soc_id       = 0x1860, /* Allwinner H713 */
+		.name         = "H713",
+		.spl_addr     = 0x20000,
+		.scratch_addr = 0x21000,
+		.thunk_addr   = 0x53a00, .thunk_size = 0x200,
+		.swap_buffers = h616_sram_swap_buffers,
+		.sram_size    = 207 * 1024,
+		.sid_base     = 0x03006000,
+		.sid_offset   = 0x200,
+		.sid_sections = generic_2k_sid_maps,
+		.rvbar_reg    = 0x09010040,
+		.rvbar_reg_alt= 0x08100040,
+		.ver_reg      = 0x03000024,
+		.watchdog     = &wd_h6_compat,
+	},{
 		.soc_id       = 0x1886, /* Allwinner V853 */
 		.name         = "V853",
 		.spl_addr     = 0x20000,


### PR DESCRIPTION
ADD: Basic soc info for H713 chip. Starting point.

Chips are being miss recognized and mistakenly wrong values are being used for addresses. This will be added later.

The full credit for this PR must go to the @shift
 owner of https://github.com/shift/sun50iw12p1-research I am only a bystander. Worth noticing that the full repository is result of some kind of vibe coding results and is hard to read and got through.

NOTICE: Please feel free to take ownership of this PR, add changes and make progress. Including merge, rebase of the head etc. Just don't wait for me in case i am not responsive in ~1-2 days 