### PR TITLE
sunxi-fel: find libfdt with pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,16 @@ ZLIB = zlib
 ZLIB_CFLAGS ?= `$(PKG_CONFIG) --cflags $(ZLIB)`
 ZLIB_LIBS ?= `$(PKG_CONFIG) --libs $(ZLIB)`
 
+LIBFDT = libfdt
+LIBFDT_PKGCONFIG := $(shell $(PKG_CONFIG) --exists $(LIBFDT) 2>/dev/null && echo y)
+ifeq ($(LIBFDT_PKGCONFIG),y)
+LIBFDT_CFLAGS ?= `$(PKG_CONFIG) --cflags $(LIBFDT)`
+LIBFDT_LIBS ?= `$(PKG_CONFIG) --libs $(LIBFDT)`
+else
+LIBFDT_CFLAGS ?=
+LIBFDT_LIBS ?= -lfdt
+endif
+
 ifeq ($(OS),Windows_NT)
 	# Windows lacks mman.h / mmap()
 	DEFAULT_CFLAGS += -DNO_MMAP
@@ -149,8 +159,8 @@ FEL_LIB  := fel_lib.c fel_lib.h
 SPI_FLASH:= fel-spiflash.c fel-spiflash.h fel-remotefunc-spi-data-transfer.h
 
 sunxi-fel: fel.c fit_image.c thunks/fel-to-spl-thunk.h $(PROGRESS) $(SOC_INFO) $(FEL_LIB) $(SPI_FLASH)
-	$(CC) $(HOST_CFLAGS) $(LIBUSB_CFLAGS) $(ZLIB_CFLAGS) $(LDFLAGS) -o $@ \
-		$(filter %.c,$^) $(LIBS) $(LIBUSB_LIBS) $(ZLIB_LIBS) -lfdt
+	$(CC) $(HOST_CFLAGS) $(LIBUSB_CFLAGS) $(ZLIB_CFLAGS) $(LIBFDT_CFLAGS) $(LDFLAGS) -o $@ \
+		$(filter %.c,$^) $(LIBS) $(LIBUSB_LIBS) $(ZLIB_LIBS) $(LIBFDT_LIBS)
 
 sunxi-nand-part: nand-part-main.c nand-part.c nand-part-a10.h nand-part-a20.h
 	$(CC) $(HOST_CFLAGS) -c -o nand-part-main.o nand-part-main.c


### PR DESCRIPTION
sunxi-fel uses libfdt to parse FIT images, but the Makefile only passed -lfdt when linking. That works when libfdt headers and libraries are installed in default compiler search paths, but fails when a package installs them elsewhere.

Use pkg-config to obtain the libfdt compiler and linker flags, matching the existing libusb and zlib handling.