### PR TITLE
Makefile: avoid GNU install options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ install-tools: $(TOOLS)
 	@set -ex ; for l in $(FEXC_LINKS) ; do \
 		ln -nfs sunxi-fexc $(DESTDIR)$(BINDIR)/$$l ; \
 	done
-	install -D -m0644 -t $(DESTDIR)$(MANDIR) sunxi-fel.1
+	install -d $(DESTDIR)$(MANDIR)
+	install -m0644 sunxi-fel.1 $(DESTDIR)$(MANDIR)/sunxi-fel.1
 
 install-target-tools: $(TARGET_TOOLS)
 	install -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
The install-tools target installs the sunxi-fel man page with "install -D -m0644 -t", which is supported by GNU install but not by BSD install. This breaks "make install" on systems such as macOS.

Create the man page directory explicitly and install the file to its full destination path instead. This matches the existing directory creation used for the binary install path and works with both GNU and BSD install.