### PR TITLE
Do not try to typedef `bool` for `bare-metal.[ch]`

### DIFF
--- a/bare-metal.c
+++ b/bare-metal.c
@@ -594,7 +594,7 @@ void uart0_puts(const char *s)
 	}
 }
 
-void uart0_puthex(unsigned long hex, bool new_line)
+void uart0_puthex(unsigned long hex, int new_line)
 {
 	unsigned int chunks = sizeof(hex) * 2;
 	unsigned int i;

--- a/bare-metal.h
+++ b/bare-metal.h
@@ -56,7 +56,6 @@
 typedef unsigned int u32;
 typedef unsigned short int u16;
 typedef unsigned char u8;
-typedef int bool;
 
 #ifndef NULL
 #define NULL ((void*)0)
@@ -220,7 +219,7 @@ void jtag_init(const struct soc_info *soc);
 void uart0_init(const struct soc_info *soc);
 void uart0_putc(char c);
 void uart0_puts(const char *s);
-void uart0_puthex(unsigned long hex, bool new_line);
+void uart0_puthex(unsigned long hex, int new_line);
 int get_boot_device(const struct soc_info *soc);
 
 #endif


### PR DESCRIPTION
Doing so results in the following with the current compiler in Debian:

```
arm-none-eabi-gcc -march=armv5te -g -Os -marm -fpic -Wall -fno-common -fno-builtin -ffreestanding -nostdinc -fno-strict-aliasing -mno-thumb-interwork -fno-stack-protector -fno-toplevel-reorder -Wstrict-prototypes -Wno-format-nonliteral -Wno-format-security jtag-loop.c bare-metal.c -nostdlib -o jtag-loop.elf -T bare-metal.lds -Wl,-N
In file included from jtag-loop.c:21:
bare-metal.h:59:13: error: 'bool' cannot be defined via 'typedef'
   59 | typedef int bool;
      |             ^~~~
bare-metal.h:59:13: note: 'bool' is a keyword with '-std=c23' onwards
```

I'd have preferred to use `stdbool.h` but that is not easily available with `-nostdinc`.

---

I don't think this is an issue with the Debian compiler, just the fact that it is new enough to have c23 support and/or this new warning.

The affected function (`uart0_puthex`) never appears to have been used from when it was introduced in 4f144b33443e7411cc7cd15436293a15f1b7d911, so I guess it could be removed, but I figured it might be useful for local debug hacking etc. Could also just remove the `newline` support I guess. 
