### PR TITLE
Use `<stdbool.h>` even on bare metal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,10 +180,14 @@ phoenix_info: phoenix_info.c
 %.sunxi: %.bin
 	$(SUNXI_BOOT_IMAGE) $< $@
 
+
+CROSS_CC_INSTALL = $(shell LANG=C $(CROSS_CC) -print-search-dirs | sed -n -e 's/install: \(.*\)/\1/p')
+
 ARM_ELF_FLAGS = -Os -marm -fpic -Wall
 ARM_ELF_FLAGS += -fno-common -fno-builtin -ffreestanding -nostdinc -fno-strict-aliasing
 ARM_ELF_FLAGS += -mno-thumb-interwork -fno-stack-protector -fno-toplevel-reorder
 ARM_ELF_FLAGS += -Wstrict-prototypes -Wno-format-nonliteral -Wno-format-security
+ARM_ELF_FLAGS += -isystem $(CROSS_CC_INSTALL)/include
 
 jtag-loop.elf: jtag-loop.c bare-metal.c bare-metal.lds
 	$(CROSS_CC) -march=armv5te -g $(ARM_ELF_FLAGS) $(filter %.c,$^) -nostdlib -o $@ -T $(lastword $^) -Wl,-N

--- a/bare-metal.c
+++ b/bare-metal.c
@@ -594,7 +594,7 @@ void uart0_puts(const char *s)
 	}
 }
 
-void uart0_puthex(unsigned long hex, bool new_line)
+void uart0_puthex(unsigned long hex, int new_line)
 {
 	unsigned int chunks = sizeof(hex) * 2;
 	unsigned int i;

--- a/bare-metal.c
+++ b/bare-metal.c
@@ -594,7 +594,7 @@ void uart0_puts(const char *s)
 	}
 }
 
-void uart0_puthex(unsigned long hex, int new_line)
+void uart0_puthex(unsigned long hex, bool new_line)
 {
 	unsigned int chunks = sizeof(hex) * 2;
 	unsigned int i;

--- a/bare-metal.h
+++ b/bare-metal.h
@@ -53,10 +53,11 @@
 #ifndef _BARE_METAL_H_
 #define _BARE_METAL_H_
 
+#include <stdbool.h>
+
 typedef unsigned int u32;
 typedef unsigned short int u16;
 typedef unsigned char u8;
-typedef int bool;
 
 #ifndef NULL
 #define NULL ((void*)0)

--- a/bare-metal.h
+++ b/bare-metal.h
@@ -56,7 +56,6 @@
 typedef unsigned int u32;
 typedef unsigned short int u16;
 typedef unsigned char u8;
-typedef int bool;
 
 #ifndef NULL
 #define NULL ((void*)0)
@@ -220,7 +219,7 @@ void jtag_init(const struct soc_info *soc);
 void uart0_init(const struct soc_info *soc);
 void uart0_putc(char c);
 void uart0_puts(const char *s);
-void uart0_puthex(unsigned long hex, bool new_line);
+void uart0_puthex(unsigned long hex, int new_line);
 int get_boot_device(const struct soc_info *soc);
 
 #endif

--- a/bare-metal.h
+++ b/bare-metal.h
@@ -56,6 +56,7 @@
 typedef unsigned int u32;
 typedef unsigned short int u16;
 typedef unsigned char u8;
+typedef int bool;
 
 #ifndef NULL
 #define NULL ((void*)0)
@@ -219,7 +220,7 @@ void jtag_init(const struct soc_info *soc);
 void uart0_init(const struct soc_info *soc);
 void uart0_putc(char c);
 void uart0_puts(const char *s);
-void uart0_puthex(unsigned long hex, int new_line);
+void uart0_puthex(unsigned long hex, bool new_line);
 int get_boot_device(const struct soc_info *soc);
 
 #endif


### PR DESCRIPTION
This is part of the compiler not the libc and so is ok to use.

This addresses this compile error with the current compiler in Debian:

```
arm-none-eabi-gcc -march=armv5te -g -Os -marm -fpic -Wall -fno-common -fno-builtin -ffreestanding -nostdinc -fno-strict-aliasing -mno-thumb-interwork -fno-stack-protector -fno-toplevel-reorder -Wstrict-prototypes -Wno-format-nonliteral -Wno-format-security jtag-loop.c bare-metal.c -nostdlib -o jtag-loop.elf -T bare-metal.lds -Wl,-N
In file included from jtag-loop.c:21:
bare-metal.h:59:13: error: 'bool' cannot be defined via 'typedef'
   59 | typedef int bool;
      |             ^~~~
bare-metal.h:59:13: note: 'bool' is a keyword with '-std=c23' onwards
```

To do this we must ensure the compilers builtin headers are available but that
the libc ones are not. I had expected `-ffreestanding` without `-nostdinc` to
accomplish this but it does not (e.g. `stdio.h` can still be incluced).

Instead keep `-nostdint` and manually fish out the compiler's include dir to be
used as a system include path `-isystem`.

With these arrangements headers from `/usr/lib/gcc/arm-none-eabi/15/include`
(which inclues `stdbool.h`) are available but those from libc, which on Debian
with `gcc-arm-none-eabi` means `/usr/arm-none-eabi/include` from
`picolibc-arm-none-eabi`, are not.

---

An alternative to #242. I don't much like the shenanigans needed to pull out `CROSS_CC_INSTALL` though.