### PR TITLE
Use `<stdbool.h>` even on bare metal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ phoenix_info: phoenix_info.c
 	$(SUNXI_BOOT_IMAGE) $< $@
 
 ARM_ELF_FLAGS = -Os -marm -fpic -Wall
-ARM_ELF_FLAGS += -fno-common -fno-builtin -ffreestanding -nostdinc -fno-strict-aliasing
+ARM_ELF_FLAGS += -fno-common -fno-builtin -ffreestanding -fno-strict-aliasing
 ARM_ELF_FLAGS += -mno-thumb-interwork -fno-stack-protector -fno-toplevel-reorder
 ARM_ELF_FLAGS += -Wstrict-prototypes -Wno-format-nonliteral -Wno-format-security
 

--- a/bare-metal.h
+++ b/bare-metal.h
@@ -53,10 +53,11 @@
 #ifndef _BARE_METAL_H_
 #define _BARE_METAL_H_
 
+#include <stdbool.h>
+
 typedef unsigned int u32;
 typedef unsigned short int u16;
 typedef unsigned char u8;
-typedef int bool;
 
 #ifndef NULL
 #define NULL ((void*)0)


### PR DESCRIPTION

This is part of the compiler not the libc and so is ok to use.

This addresses this compile error with the current compiler in Debian:

```
arm-none-eabi-gcc -march=armv5te -g -Os -marm -fpic -Wall -fno-common -fno-builtin -ffreestanding -nostdinc -fno-strict-aliasing -mno-thumb-interwork -fno-stack-protector -fno-toplevel-reorder -Wstrict-prototypes -Wno-format-nonliteral -Wno-format-security jtag-loop.c bare-metal.c -nostdlib -o jtag-loop.elf -T bare-metal.lds -Wl,-N
In file included from jtag-loop.c:21:
bare-metal.h:59:13: error: 'bool' cannot be defined via 'typedef'
   59 | typedef int bool;
      |             ^~~~
bare-metal.h:59:13: note: 'bool' is a keyword with '-std=c23' onwards
```

To allow the use of `stdbool` drop use of `-nostdinc` when building bare metal
components. We will rely on the link phase and `-ffreestanding` along with
`-nostdlib` to prevent accidental use of stdlib features.

Signed-off-by: Ian Campbell <ijc@debian.org>
