### PR TITLE
Secure boot H616/A133 support

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -565,35 +565,45 @@ void aw_set_sctlr(feldev_handle *dev, soc_info_t *soc_info,
 }
 
 /*
- * Issue a "smc #0" instruction. This brings a SoC booted in "secure boot"
- * state from the default non-secure FEL into secure FEL.
- * This crashes on devices using "non-secure boot", as the BROM does not
- * provide a handler address in MVBAR. So we have a runtime check.
+ * When a SoC is configured for "secure boot", the FEL code is running in
+ * non-secure SVC mode, which denies access to secure state system registers
+ * like CNTFRQ, the secure GIC configuration registers or the RMR register to
+ * switch to AArch64.
+ * Thankfully there are ways to break out of this non-secure prison, how
+ * exactly is varying between the SoCs.
  */
-void aw_apply_smc_workaround(feldev_handle *dev)
+static void handle_secure_boot(feldev_handle *dev)
 {
 	soc_info_t *soc_info = dev->soc_info;
 	uint32_t val;
-	uint32_t arm_code[] = {
+	const uint32_t arm_smc_code[] = {
 		htole32(0xe1600070), /* smc	#0	*/
 		htole32(0xe12fff1e), /* bx	lr	*/
 	};
 
-	/* Return if the SoC does not need this workaround */
-	if (!soc_info->needs_smc_workaround_if_zero_word_at_addr)
+	/*
+	 * Check whether the SoC is using secure boot, and if the workaround
+	 * has already been applied.
+	 */
+	switch (soc_info->sec_boot_wa) {
+	case SECURE_BOOT_NONE:
 		return;
+	case SECURE_BOOT_SMC:
+		aw_fel_read(dev, soc_info->sec_mem_addr, &val, sizeof(val));
+		if (val != 0)
+			return;
+		/*
+		 * H3, H5, A64 just need a simple SMC, which will magically
+		 * return in secure state, with all the system registers
+		 * already fixed up.
+		 */
+		pr_info("Applying secure boot SMC workaround... ");
+		aw_fel_write(dev, arm_smc_code, soc_info->scratch_addr,
+			     sizeof(arm_smc_code));
+		aw_fel_execute(dev, soc_info->scratch_addr);
+		break;
+	}
 
-	/* This has less overhead than fel_readl_n() and may be good enough */
-	aw_fel_read(dev, soc_info->needs_smc_workaround_if_zero_word_at_addr,
-	            &val, sizeof(val));
-
-	/* Return if the workaround is not needed or has been already applied */
-	if (val != 0)
-		return;
-
-	pr_info("Applying SMC workaround... ");
-	aw_fel_write(dev, arm_code, soc_info->scratch_addr, sizeof(arm_code));
-	aw_fel_execute(dev, soc_info->scratch_addr);
 	pr_info(" done.\n");
 }
 
@@ -1381,8 +1391,7 @@ int main(int argc, char **argv)
 	 */
 	handle = feldev_open(busnum, devnum, AW_USB_VENDOR_ID, AW_USB_PRODUCT_ID);
 
-	/* Some SoCs need the SMC workaround to enter the secure boot mode */
-	aw_apply_smc_workaround(handle);
+	handle_secure_boot(handle);
 
 	/* Handle command-style arguments, in order of appearance */
 	while (argc > 1 ) {

--- a/fel.c
+++ b/fel.c
@@ -564,6 +564,41 @@ void aw_set_sctlr(feldev_handle *dev, soc_info_t *soc_info,
 	aw_write_arm_cp_reg(dev, soc_info, 15, 0, 1, 0, 0, sctlr);
 }
 
+static void upload_h6_secure_boot_wa(feldev_handle *dev, uint32_t scratch_addr)
+{
+	const uint32_t arm_h6_mon_code[] = {
+	htole32(0xe1600070),	/* smc	#0		; trigger SMC	*/
+	htole32(0xe3a02403),	/* mov	r2, #0x3000000	; sys resource base */
+	htole32(0xe3822a22),	/* orr	r2, r2, #0x22000; GICC base address */
+	htole32(0xe5920000),	/* ldr	r0, [r2]	; load GICC_CTLR */
+	htole32(0xe380000f),	/* orr	r0, r0, #0x6	; set ACKCTL+Grp1En */
+	htole32(0xe5820000),	/* str	r0, [r2]	; write new GICC_CTLR */
+	htole32(0xe3a00000),	/* mov	r0, #0		; .NS=0: secure state */
+	htole32(0xee010f11),	/* mcr	15, 0, r0, c1, c1, 0 ; SCR	*/
+	htole32(0xe10f0000),	/* mrs	r0, CPSR			*/
+	htole32(0xe3c0001f),	/* bic	r0, r0, #0x1f	; clear .M field */
+	htole32(0xe3800013),	/* orr	r0, r0, #0x13	; force SVC mode */
+	htole32(0xe121f000),	/* msr	CPSR_c, r0	; switch to SVC mode */
+	htole32(0xe12fff1e),	/* bx	lr		; return to BootROM */
+	};
+	uint32_t val;
+
+	/*
+	 * The A133 BootROM clears all of SRAM when entering non-secure
+	 * state, which includes the monitor vectors. MVBAR still points
+	 * into the SRAM region, but there is nothing there anymore.
+	 * Just replace the vector address we need (MVBAR + 0x8) which
+	 * the opcode for a "mov pc, lr", to immediately return to
+	 * the caller. The MVBAR value has been found by BROM inspection
+	 * and has been verified by experiments.
+	 */
+	val = htole32(0xe1a0f00e);	/* mov pc, lr */
+	aw_fel_write(dev, &val, 0x300c8, sizeof(val));
+
+	aw_fel_write(dev, arm_h6_mon_code, scratch_addr,
+		     sizeof(arm_h6_mon_code));
+}
+
 /*
  * When a SoC is configured for "secure boot", the FEL code is running in
  * non-secure SVC mode, which denies access to secure state system registers
@@ -600,6 +635,25 @@ static void handle_secure_boot(feldev_handle *dev)
 		pr_info("Applying secure boot SMC workaround... ");
 		aw_fel_write(dev, arm_smc_code, soc_info->scratch_addr,
 			     sizeof(arm_smc_code));
+		aw_fel_execute(dev, soc_info->scratch_addr);
+		break;
+	case SECURE_BOOT_MONITOR_H6:
+		/* +0xa0 is the "secure boot register" in the SID. */
+		val = fel_readl(dev, soc_info->sid_base + 0xa0);
+		if (val == 0)
+			return;
+		/*
+		 * Now check whether the workaround has already been applied.
+		 * Read the LCJS efuse, which is only accessible from secure
+		 * state (reads as 0 otherwise), and holds the secure boot
+		 * fuse, so its value is 0 on normal SoCs.
+		 */
+		val = fel_readl(dev, soc_info->sid_base + 0x248);
+		if (val != 0)
+			return;
+
+		upload_h6_secure_boot_wa(dev, soc_info->scratch_addr);
+		pr_info("Applying secure boot H6 monitor workaround... ");
 		aw_fel_execute(dev, soc_info->scratch_addr);
 		break;
 	}

--- a/soc_info.c
+++ b/soc_info.c
@@ -395,8 +395,9 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.sid_sections = h3_sid_maps,
 		.rvbar_reg    = 0x017000A0,
+		.sec_boot_wa  = SECURE_BOOT_SMC,
 		/* Check L.NOP in the OpenRISC reset vector */
-		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
+		.sec_mem_addr = 0x40004,
 		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1639, /* Allwinner A80 */
@@ -443,8 +444,9 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.sid_fix      = true,
 		.sid_sections = h3_sid_maps,
+		.sec_boot_wa  = SECURE_BOOT_SMC,
 		/* Check L.NOP in the OpenRISC reset vector */
-		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
+		.sec_mem_addr = 0x40004,
 		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1681, /* Allwinner V3s */
@@ -481,8 +483,9 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.sid_sections = h3_sid_maps,
 		.rvbar_reg    = 0x017000A0,
+		.sec_boot_wa  = SECURE_BOOT_SMC,
 		/* Check L.NOP in the OpenRISC reset vector */
-		.needs_smc_workaround_if_zero_word_at_addr = 0x40004,
+		.sec_mem_addr = 0x40004,
 		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1701, /* Allwinner R40 */
@@ -520,8 +523,9 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.sid_sections = h6_sid_maps,
 		.rvbar_reg    = 0x09010040,
+		.sec_boot_wa  = SECURE_BOOT_SMC,
 		/* Check L.NOP in the OpenRISC reset vector */
-		.needs_smc_workaround_if_zero_word_at_addr = 0x100004,
+		.sec_mem_addr = 0x100004,
 		.watchdog     = &wd_h6_compat,
 	},{
 		.soc_id       = 0x1816, /* Allwinner V536 */
@@ -640,7 +644,6 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.sid_sections = generic_2k_sid_maps,
 		.rvbar_reg    = 0x08100040,
-		.needs_smc_workaround_if_zero_word_at_addr = 0x100004,
 		.watchdog     = &wd_h6_compat,
 	},{
 		.swap_buffers = NULL /* End of the table */

--- a/soc_info.c
+++ b/soc_info.c
@@ -564,6 +564,7 @@ soc_info_t soc_info_table[] = {
 		.sid_sections = generic_2k_sid_maps,
 		.rvbar_reg    = 0x09010040,
 		.rvbar_reg_alt= 0x08100040,
+		.sec_boot_wa  = SECURE_BOOT_MONITOR_H6,
 		.ver_reg      = 0x03000024,
 		.watchdog     = &wd_h6_compat,
 	},{
@@ -644,6 +645,7 @@ soc_info_t soc_info_table[] = {
 		.sid_offset   = 0x200,
 		.sid_sections = generic_2k_sid_maps,
 		.rvbar_reg    = 0x08100040,
+		.sec_boot_wa  = SECURE_BOOT_MONITOR_H6,
 		.watchdog     = &wd_h6_compat,
 	},{
 		.swap_buffers = NULL /* End of the table */

--- a/soc_info.h
+++ b/soc_info.h
@@ -76,6 +76,11 @@ typedef struct {
 	.size_bits = _size_bits,			\
 }
 
+enum secure_boot_workaround {
+	SECURE_BOOT_NONE = 0,
+	SECURE_BOOT_SMC,	/* A simple 'smc #0' does the trick. */
+};
+
 /*
  * Each SoC variant may have its own list of memory buffers to be exchanged
  * and the information about the placement of the thunk code, which handles
@@ -99,20 +104,19 @@ typedef struct {
  * address must be 16K aligned.
  *
  * If an SoC has the "secure boot" fuse burned, it will enter FEL mode in
- * non-secure state, so with the SCR.NS bit set. Since in this mode the
- * secure/non-secure state restrictions are actually observed, we suffer
+ * non-secure state, so with the SCR.NS bit set. Since in this mode more of
+ * the secure/non-secure state restrictions are actually observed, we suffer
  * from several restrictions:
- * - No access to the SID information (both via memory mapped and "register").
- * - No access to secure SRAM (SRAM A2 on H3/A64/H5).
+ * - No access to the SID information (on earlier SoCs like H3/A64/H5).
+ * - No access to secure SRAM (on earlier SoCs like H3/A64/H5).
  * - No access to the secure side of the GIC, so it can't be configured to
  *   be accessible from non-secure world.
  * - No RMR trigger on ARMv8 cores to bring the core into AArch64.
- * However it has been found out that a simple "smc" call will immediately
- * return from monitor mode, but with the NS bit cleared, so access to all
- * secure peripherals is suddenly possible.
- * The 'needs_smc_workaround_if_zero_word_at_addr' field can be used to
- * have a check for this condition (reading from restricted addresses
- * typically returns zero) and then activate the SMC workaround if needed.
+ * Depending on the SoC there are workarounds to bring us into secure state,
+ * 'secure_boot_wa' selects one of the methods. Since most workarounds must
+ * only be applied once, we need to first check if secure boot is enabled and
+ * if the workaround has already been applied. 'secure_mem_addr' holds a SoC
+ * specific address that can be used to determine the secure boot status.
  */
 typedef struct {
 	uint32_t           soc_id;       /* ID of the SoC */
@@ -133,8 +137,9 @@ typedef struct {
 	bool               sid_fix;      /* Use SID workaround (read via register) */
 	/* Use I$ workaround (disable I$ before first write to prevent stale thunk */
 	bool               icache_fix;
-	/* Use SMC workaround (enter secure mode) if can't read from this address */
-	uint32_t           needs_smc_workaround_if_zero_word_at_addr;
+	enum secure_boot_workaround	sec_boot_wa;
+	/* A secure-only memory address with non-zero content */
+	uint32_t           sec_mem_addr;
 	uint32_t           sram_size;	/* Usable contiguous SRAM at spl_addr */
 	sram_swap_buffers *swap_buffers;
 } soc_info_t;

--- a/soc_info.h
+++ b/soc_info.h
@@ -79,6 +79,7 @@ typedef struct {
 enum secure_boot_workaround {
 	SECURE_BOOT_NONE = 0,
 	SECURE_BOOT_SMC,	/* A simple 'smc #0' does the trick. */
+	SECURE_BOOT_MONITOR_H6, /* SMC returns in monitor mode, needs fixing. */
 };
 
 /*


### PR DESCRIPTION
When an Allwinner device has the "secure boot" fuse burnt, FEL mode works differently, and we deployed some workaround code to bring FEL back into the secure world, which we rely on in the firmware.
This simple SMC workaround only worked on H3, H5, and A64, so we need new workaround code for the A133 and H616. The H6 might be in the same camp, but that needs confirmation (@smaeul?)

Factor out the existing A64 workaround code, to allow specifying multiple methods, as there will be more to come (the A523 surely needs a change at least for its GICv3).
Then the second patch introduces the code for the H616 and A133 SoCs. The assembly sequence has been developed by experimentation, mostly by comparing the CPU and system IP state between the working (non-secure) SVC mode, and the monitor mode. At the end it's really just the GIC which needs a bit or two tweaked, and switching to secure-SVC: staying in monitor mode doesn't work with the BootROM code.
The detection routine is also custom and quite different, since newer SoCs restrict less of the system when running in non-secure state. Thanks to @jameshilliard for finding the 0xa0 SID register.

I refrained from parametrising the code too much: the workaround is only applicable for a few SoCs (just two actually atm), and the GIC base address and MVBAR value plus the detection logic is the same across both. So we can hardcode this in the code, which simplifies things, and avoids fragile PC relative loads in our encoded assembly instructions.